### PR TITLE
Restore overwrites and update links from prior merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ## Background
 
-This repository details how changes to the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/Roadmap), and [Supporting Documentation](https://github.com/solid/information/blob/master/documentation/documentation.md) may be proposed and accepted.
+This repository details how changes to the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/roadmap), and [Supporting Documentation](editors.md#supporting-documentation) may be proposed and accepted.
 
-Anyone may participate in [this process](https://github.com/solid/culture). Please read the [Code of Conduct](code-of-conduct.md) before doing so.
+Anyone may participate in [this process](https://github.com/solid/process). Please read the [Code of Conduct](code-of-conduct.md) before doing so.
 
 ## Contributors
 
-Any individual that has been involved in proposals to improve the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/Roadmap), and [Supporting Documentation](https://github.com/solid/information/blob/master/documentation/documentation.md), has provided a valuable service to the [Solid Project](https://www.solidproject.org) and is encouraged to continue.
+Any individual that has been involved in proposals to improve the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/roadmap), and [Supporting Documentation](editors.md#supporting-documentation), has provided a valuable service to the [Solid Project](https://www.solidproject.org) and is encouraged to continue.
 
 All manner of contributions are important - whether identifying problems, asking questions, or proposing normative changes.
 
@@ -14,7 +14,7 @@ There are many topics, problems, or ideas best tackled by a group of people with
 
 ### Solid Panels
 
-Solid Panels are groups of individuals focused on a specific problem or domain relevant to Solid, with an aim to propose changes to the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/Roadmap), and/or [Supporting Documentation](https://github.com/solid/information/blob/master/documentation/documentation.md). Anyone may join a panel or suggest a new panel.
+Solid Panels are groups of individuals focused on a specific problem or domain relevant to Solid, with an aim to propose changes to the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/roadmap), and/or [Supporting Documentation](editors.md#supporting-documentation). Anyone may join a panel or suggest a new panel.
 
 Domains may be technical, non-technical, or some combination of the two. For example, a Security Panel could focus on the evaluation and advancement of the Solid security model.
 
@@ -26,7 +26,7 @@ Panels may request to have a gitter channel created within the [Solid Gitter Org
 
 ## Stakeholders
 
-Stakeholders are those affected by normative changes to the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/Roadmap), or [Supporting Documentation](https://github.com/solid/information/blob/master/documentation/documentation.md). There are two types of Stakeholders; [Solid Users](#solid-users) and [Solid Implementers](#solid-implementers). It is important to consider them both when proposing changes, and adhering to the W3C [priority of constituencies](https://www.w3.org/TR/html-design-principles/#priority-of-constituencies) is encouraged. A Stakeholder may be both a user and an implementer.
+Stakeholders are those affected by normative changes to the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/roadmap), or [Supporting Documentation](editors.md#supporting-documentation). There are two types of Stakeholders; [Solid Users](#solid-users) and [Solid Implementers](#solid-implementers). It is important to consider them both when proposing changes, and adhering to the W3C [priority of constituencies](https://www.w3.org/TR/html-design-principles/#priority-of-constituencies) is encouraged. A Stakeholder may be both a user and an implementer.
 
 Stakeholders who have opted to identify themselves publicly are listed at [stakeholders.md](stakeholders.md). Anyone may decide to identify themselves publicly as a Solid Stakeholder, but it is not mandatory. Identified stakeholders may be consulted for feedback as part of the editorial process.
 
@@ -39,20 +39,20 @@ Solid Implementers are companies or organizations who are implementing the [Soli
 
 ## How to Make Changes
 
-This section details how changes to the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/Roadmap), and [Supporting Documentation](https://github.com/solid/information/blob/master/documentation/documentation.md) may be drafted, proposed, and accepted.
+This section details how changes to the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/roadmap), and [Supporting Documentation](editors.md#supporting-documentation) may be drafted, proposed, and accepted.
 
 Anyone may submit a proposal to alter this process. These proposals will not be reviewed by the editors. They will be reviewed only by [Tim Berners-Lee](https://github.com/timbl), who is the Solid Director.
 
 ### Drafting proposals
 
-Anyone may propose improvements to the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/Roadmap), or [Supporting Documentation](https://github.com/solid/information/blob/master/documentation/documentation.md). Here are some examples of different ways to contribute:
+Anyone may propose improvements to the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/roadmap), or [Supporting Documentation](editors.md#supporting-documentation). Here are some examples of different ways to contribute:
 
 - Submit a pull request or issue on the [Solid Specification repository](https://github.com/solid/solid-spec) in GitHub
 - Make a suggestion to the Solid Authorization Panel chat room about a change you'd like to see in Web Access Control
 - Make a suggestion on the Solid W3C Community Group mailing list to form a new Solid Panel, or join an existing Solid Panel
 - Propose an item for the W3C Solid Community Group call
 
-Proposals for substantive changes to the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/Roadmap), or [Supporting Documentation](https://github.com/solid/information/blob/master/documentation/documentation.md) go through an editorial review process. A change is considered substantive when it alters the normative text of the Solid Specification or the Solid Roadmap. Any proposal must be realistic and reasonable to implement, preferably with example implementations, and demonstrable support from Implementers.
+Any proposal must be realistic and reasonable to implement, preferably with example implementations, and demonstrable support from Implementers.
 
 Any proposal should also be accompanied with a reasonable explanation of the need for the proposed change. For example:
 
@@ -66,8 +66,7 @@ When there are objections, notify the Solid Panels and Stakeholders about the fi
 
 ### Reviewing proposals
 
-Candidate proposals to the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/Roadmap), or [Supporting Documentation](https://github.com/solid/information/blob/master/documentation/documentation.md) submitted for review go through an editorial process before they are accepted.
-Candidate Proposals to change the Solid Specification, Solid Roadmap, or Supporting Documentation must be submitted for editorial review before they are accepted, along with the results of any votes taken.
+Candidate Proposals to change the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/roadmap), or [Supporting Documentation](editors.md#supporting-documentation) must be submitted for editorial review before they are accepted, along with the results of any votes taken.
 
 An Editor determines whether a Candidate Proposal includes a substantive change and marks it accordingly. If there is any disagreement among Editors, the Candidate Proposal will be automatically marked as including a substantive change.
 
@@ -91,7 +90,7 @@ Editors have [_Admin Permissions_](https://help.github.com/en/articles/repositor
 
 ## Administration
 
-Administrators are granted privileged access to control the tools, systems, and services used for advancing the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/Roadmap), and [Supporting Documentation](https://github.com/solid/information/blob/master/documentation/documentation.md). This includes the [Solid GitHub](https://github.com/solid) organization, [Solid Gitter](https://gitter.im/solid/home) channels, the [Solid Forum](https://forum.solidproject.org), and the [Solid Website](https://www.solidproject.org).
+Administrators are granted privileged access to control the tools, systems, and services used for advancing the [Solid Specification](https://github.com/solid/specification), [Solid Roadmap](https://github.com/solid/roadmap), and [Supporting Documentation](editors.md#supporting-documentation). This includes the [Solid GitHub](https://github.com/solid) organization, [Solid Gitter](https://gitter.im/solid/home) channels, the [Solid Forum](https://forum.solidproject.org), and the [Solid Website](https://www.solidproject.org).
 
 Administrators belong to the [Administrators Team](https://github.com/orgs/solid/teams/administrators) in the [Solid GitHub Organization](https://github.com/solid) and have [_Admin Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) on all repositories therein. Administrators have [_Owner Permissions_](https://help.github.com/en/articles/permission-levels-for-an-organization#permission-levels-for-an-organization) for the [Solid GitHub Organization](https://github.com/solid).
 


### PR DESCRIPTION
The merge of #95 introduced a number of changes into the process documentation. 

#83 added links throughout the documentation, and was merged shortly after. However, the pull request for #83 was submitted several weeks before #95 was completed. While it looks like most of the conflicts were correctly resolved, there were two cases where the language approved as part of the #95 merge was overwritten with earlier versions, at lines 55 and 69 (see the Files Changed tab). This pull request restores the approved language as it was written in #95 (with the addition of links at line 69 to maintain consistency with the changes from #83).

Two additional items identified and addressed by this pull:

1. Because #83 was written before the repository name was changed, it was still referring to the previous repository address - solid/culture. That reference has been updated to the current address of solid/process.
1. At the time that #83 was written, there was not an approved definition of what constitutes Supporting Documentation from an editorial standpoint. With the passage of #95, this was defined in [editors.md](editors.md#supporting-documentation). Those link references have also been updated to link there instead.

I believe this pull should only require standard editorial review, since the changes proposed are meant to align documentation with the material that @timbl has already approved.