### PR TITLE
editors to focus on specification

### DIFF
--- a/editors.md
+++ b/editors.md
@@ -95,33 +95,3 @@ __Primary Documents:__
 Pertaining to mechanisms used and considerations taken when securing a data pod, a conformant server implementation, and/or the immediate ecosystem around them.  
 __Assigned Editors:__ Justin Bingham    
 __Primary Documents:__ [solid/specification/security](https://github.com/solid/specification/blob/master/main/security.bs)
-
-### Solid Roadmap
-
-The Solid Roadmap includes the vision, goals, direction, and key success factors for the Solid and its surrounding ecosystem.  
-__Assigned Editors:__  Kjetil Kjernsmo, Justin Bingham, Ruben Verborgh, Sarven Capadisli   
-__Primary Documents:__ [solid/roadmap](https://github.com/solid/roadmap)
-
-### Supporting Documentation
-
-The Solid Specification, Roadmap, and the greater ecosystem are supported by various forms of documentation and supplementary content, from the process and updates to web sites and tutorials.
-
-#### Solid Process
-Official process that details how changes to the Solid Specification, Solid Roadmap, and Supporting Documentation may be proposed and accepted.  
-__Assigned Editors:__ Justin Bingham    
-__Primary Documents:__ [solid/process](https://github.com/solid/process)
-
-#### solidproject.org
-The official project website.  
-__Assigned Editors:__ Justin Bingham    
-__Primary Documents:__ [solid/solidproject.org](https://github.com/solid/solidproject.org)
-
-#### solid.mit.edu
-Home of the original Solid MIT project.  
-__Assigned Editors:__ *No editors assigned yet*  
-__Primary Documents:__ [solid/solid.mit.edu](https://github.com/solid/solid.mit.edu)
-
-#### Solid Information
-A collection of informational resources about Solid and its ecosystem.  
-__Assigned Editors:__ *No editors assigned yet*   
-__Primary Documents:__ [solid/information](https://github.com/solid/information), [solid/solid](https://github.com/solid/solid)


### PR DESCRIPTION
Content creation for documentation currently falls under the editorial process. The specification work is very time consuming and perhaps we could give the editors more focus by allocating some of the other tasks to a dedicated team which I have called the 'creators' under solid project.org website. 

There isn't a clear description of what the roadmap so perhaps we can remove that from the editorial process until there is greater clarity on the scope of the roadmap.