### PR TITLE
Process Proposal Following Gap Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,80 @@ Anyone may participate in [this process](https://github.com/solid/process). Plea
 
 Anyone may submit a proposal to alter this process. These proposals will not be reviewed by the editors. They will be reviewed only by [Tim Berners-Lee](https://github.com/timbl), who is the Solid Director.
 
-## Contributors
+## Roles
 
 Any individual that has been involved in proposals to improve the [Solid](https://github.com/solid/specification) has provided a valuable service to the [Solid Project](https://www.solidproject.org) and is encouraged to continue.
 
 All manner of contributions are important - whether identifying problems, asking questions, or proposing normative changes.
 
 There are many problems and ideas best tackled by a group of people with a specific set of domain expertise called Solid Topics. All contributors are listed as having domain expertise on specific Solid Topics. 
+
+### Director 
+The Director is [Tim Berners-Lee](https://github.com/timbl) who is responsible for reviewing process proposals, role applications, and solidproject.org drafts. The Director can also veto decisions by editors about [Solid](https://github.com/solid/specification). 
+
+### [Manager](https://github.com/solid/process/blob/master/manager.md)
+The [Manager](https://github.com/solid/process/blob/master/manager.md) is appointed directly by the Director.
+
+The [Manager](https://github.com/solid/process/blob/master/manager.md) is responsibile for ensuring developers and those paying for developers are accurately aware of what Solid is, that there are clear instructions describing to developers how to implement Solid. The [Manager](https://github.com/solid/process/blob/master/manager.md) is also responsible for moderating the standardisation of how to build Pods, apps, and identification, in such a way that users can conveniently switch between the components and take the data generated along. 
+
+Specific tasks include but are not limited to: 
+* Events: Encourage and support Solid Event organisers by offering calls to brainstorm around finding local hosting facilities, promoting their event within local developer communities and other event organisation related concerns. Ensure that Solid t-shirts and stickers are sent to Solid event organisers and links to Solid events are published on solidproject.org and in This Week in Solid. 
+*	Newsletter: Send the This Week in Solid newsletter via Tiny Letter using the content openly developed on GitHub
+*	Solidproject.org: coordinate with the Creators to keep content such as app, Pod, and identity listings, press, documentation, tools, tutorials, and libraries up to date 
+*	Public Speaking: Respond to public speaking requests about Solid either by presenting or supporting to find public speakers who are able to present on Solid 
+* Support: Ensure that there are clear instructions describing to developers how to implement Solid, for example by facilitating online conversations where developers implementing Solid can ask questions and receive answers to clarify doubts about more advanced questions about the implementation of Solid. This could happen, for example, on the Solid Forum or via an FAQ page on solidproject.org.  
+*  Metrics: record data on the first of every month to quantify the amount of implementation of  Solid
+*	W3C Solid Community Group Call: Moderate a weekly hour long W3C Solid Community Group call where anyone can drop by to introduce themselves and ask questions. 
+*	Process: maintain a public repository explaining how individuals can contribute to the standardisation process effectively and efficiently. Ensure that the Solid GitHub account and gitter is well organised so individuals working there know where to contribute what where. Facilitate a common understanding between editors and panellists about the scope of the immediate sprint in the coming months. Make arrangements so that editors and panellists have regular calls with clear aims.  
+*	Moderate: moderate the pathways to make sure that contributors have the space to work while giving others the space to create alongside them.  Ensure that Solid panellists have the tools to facilitate consensus among panellists working on the Solid standard when difficult issues arise. This may involve a series of one-on-one conversations, facilitation of small group discussions, public suggestion of paths forward in the appropriate forum, and collection of feedback.
+
+The [Manager](https://github.com/solid/process/blob/master/manager.md) has [Admin Permissions](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) of all respositories in the [Solid GitHub](https://github.com/solid) as well as  any other tools used for the Solid Project.
+
+Meetings that the [Manager](https://github.com/solid/process/blob/master/manager.md) needs to attend include: 
+* Weekly W3C Solid Community Group Call
+* Monthly Administrator call
+* Biweekly Creators call 
+* Weekly Editor Call
+
+If it is not possible to reach the [Manager](https://github.com/solid/process/blob/master/manager.md) for four consequetive weeks without explanation or previous arrangements being made to ensure that the responsibilities are fulfilled in the interim period that the Manager is away then the Manager will be delisted in [manager.md](https://github.com/solid/process/blob/master/manager.md) by the Director and a new Manager will be appointed by the Director. 
+
+### [Administrators](administrators.md) 
+Administrators are appointed by the Solid Director. Administrators are listed at [administrators.md](administrators.md) along with their contact details and affiliations. Anyone may apply to be an Administrator. Administrator applications are not reviewed by other Administrators. They are reviewed only by the Solid Director.
+
+Administrators are responsible for ensuring that tools, systems, and services used for advancing the Solid are are carefully and securly controlled and maintained.  This includes the [Solid GitHub](https://github.com/solid) organizstion, [Solid Gitter](https://gitter.im/solid/home) channels, the [Solid Forum](https://forum.solidproject.org), and the [Solid Website](https://www.solidproject.org).
+
+Administrators belong to the [Administrators Team](https://github.com/orgs/solid/teams/administrators) in the [Solid GitHub Organization](https://github.com/solid) and have [_Admin Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) on all repositories therein. Administrators have [_Owner Permissions_](https://help.github.com/en/articles/permission-levels-for-an-organization#permission-levels-for-an-organization) for the [Solid GitHub Organization](https://github.com/solid).
+
+Meetings that the [Administrators](https://github.com/solid/process/blob/master/manager.md) need to attend include: 
+* Monthly Administrator call 
+
+If it is not possible to reach a [Administrator](administrators.md) for four consequetive weeks without explanation or previous arrangements being made to ensure that the responsibilities are fulfilled in the interim period that the Administrator will be delisted on [adminstrators.md](administrators.md) by the Manager indicating that they are inactive.  
+
+### [Creators](https://github.com/solid/process/blob/master/creators.md)
+[Creators](https://github.com/solid/process/blob/master/creators.md) are appointed by the Solid Director. Creators are listed at [creators.md](creators.md) along with their contact details and affiliations. Anyone may apply to be a Crator. Creators applications are not reviewed by other Creators. They are reviewed only by the Solid Director.
+
+Creators are responsible for writting and designing content updates for the website solidproject.org and newsletter This Week in Solid. Creators are responsible for processing suggestions made by the open community to improve solidproject.org and This Week in Solid including responsiding to the person making the suggestion and explaining how it has been incorporated or not and why.  
+
+Creators belong to the [Creators Team](https://github.com/orgs/solid/teams/creators) in the [Solid GitHub Organization](https://github.com/solid) and have [_Admin Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) on the [solidproject.org](https://github.com/solid/solidproject.org) repository and [solid.github.io](https://github.com/solid/solid.github.io) repository. 
+
+Meetings that the [Creators](https://github.com/solid/process/blob/master/creators.md) need to attend include: 
+* Biweekly Creator call
+
+If it is not possible to reach a [Creator](https://github.com/solid/process/blob/master/creators.md) for four consequetive weeks without explanation or previous arrangements being made to ensure that the responsibilities are fulfilled in the interim period that the Creator will be delisted on [creators.md](https://github.com/solid/process/blob/master/creators.md) by the Manager indicating that they are inactive.  
+
+### Editors 
+Editor appointments and their respective assignments to a specific Solid Topic are made by the Solid Director. The Editorial Team is comprised of all the Editors appointed by the Solid Director, who are listed at [editors.md](editors.md), along with their Solid Topic, contact details, and affiliations. Anyone may apply to be an Editor, and must include one or more requested Solid Topics as part of their application. These requests are not reviewed by other Editors. They are reviewed only by the Solid Director. Editor applications that can demonstrate the support of a relevant panel or group of community members will be favorably considered. Editors belong to the 
+
+[Solid Editors](editors.md) are individuals who are  responsible for editing [Solid](https://github.com/solid/specification) including processing change proposals as explained below and ensuring that conversations that have happened about Solid are reflected in the [Solid repository](https://github.com/solid/specification). 
+
+[Editorial Team](https://github.com/orgs/solid/teams/editors) in the [Solid GitHub Organization](https://github.com/solid).
+
+Editors have [Admin Permissions](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) of the [Solid repository](https://github.com/solid/specification). 
+
+Meetings that the [Editors](https://github.com/solid/process/blob/master/editors.md) need to attend include: 
+* Weekly Editor call 
+
+If it is not possible to reach an [Editor](https://github.com/solid/process/blob/master/editors.md) for four consequetive weeks without explanation or previous arrangements being made to ensure that the responsibilities are fulfilled in the interim period that the Editor will be delisted on [editors.md](https://github.com/solid/process/blob/master/editors.md) by the Manager indicating that they are inactive.
 
 ### Panellists 
 A [Solid Panel](#solid-panels) is a group of individuals focused a specific Solid Topic with a defined aim. Solid Panels author proposals to change [Solid](https://github.com/solid/specification). 
@@ -21,18 +88,9 @@ Domains may be technical, non-technical, or some combination of the two. For exa
 
 A list of Solid Panels is maintained at [panels.md](panels.md). This listing helps people find panels they may want to participate in, and helps editors find panels to consult as part of the editorial process.
 
-Panels that are inactive for more than six months may be archived by Solid Administrators.
+Panels that are inactive for more than three months may be archived by the Manager. Inactive Solid panels can be activated at any point by anyone and there must be immediate and sustained demonstratable activity in the form of contributions on Solid [issues](https://github.com/solid/specification/issues) and [pull requests](https://github.com/solid/specification/pulls) associated to the topic for the [next upcoming milestone](https://github.com/solid/specification/milestones).  
 
 Panellists belong to the [Panllist Team](https://github.com/orgs/solid/teams/panellists) in the [Solid GitHub Organization](https://github.com/solid).
-
-### Editors 
-[Solid Editors](editors.md) are individuals who are collectively responsible for editing [Solid](https://github.com/solid/specification). 
-
-Editor appointments and their respective assignments to a specific Solid Topic are made by the Solid Director. The Editorial Team is comprised of all the Editors appointed by the Solid Director, who are listed at [editors.md](editors.md), along with their Solid Topic, contact details, and affiliations. Anyone may apply to be an Editor, and must include one or more requested Solid Topics as part of their application. These requests are not reviewed by other Editors. They are reviewed only by the Solid Director. Editor applications that can demonstrate the support of a relevant panel or group of community members will be favorably considered.
-
-Editors belong to the [Editorial Team](https://github.com/orgs/solid/teams/editors) in the [Solid GitHub Organization](https://github.com/solid).
-
-Editors have [Admin Permissions](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) of the [Solid repository](https://github.com/solid/specification). 
 
 ## How to Make Changes to [Solid](https://github.com/solid/specification)
 
@@ -72,23 +130,7 @@ Candidate Proposals with substantive changes require three Editors who are assig
 
 Candidate Proposals without substantive changes require one Editor assigned to the material being modified to actively approve the proposal, with no Editors from the Editorial Team actively rejecting, and may be merged immediately by an assigned Editor. An assigned Editor may approve and merge their own non-substantive changes. Anyone from the Editorial Team has the right to revert a non-substantive change, but are encouraged to communicate with the assigned Editor that merged it first. Any revert must be accompanied by a reasonable explanation. If the change is reverted because they believe it to be substantive, that must be included in the explanation.
 
-# Administration
-
-Administrators are granted privileged access to control the tools, systems, and services used for advancing the Solid. This includes the [Solid GitHub](https://github.com/solid) organization, [Solid Gitter](https://gitter.im/solid/home) channels, the [Solid Forum](https://forum.solidproject.org), and the [Solid Website](https://www.solidproject.org).
-
-Administrators belong to the [Administrators Team](https://github.com/orgs/solid/teams/administrators) in the [Solid GitHub Organization](https://github.com/solid) and have [_Admin Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) on all repositories therein. Administrators have [_Owner Permissions_](https://help.github.com/en/articles/permission-levels-for-an-organization#permission-levels-for-an-organization) for the [Solid GitHub Organization](https://github.com/solid).
-
-### Becoming an Administrator
-
-Administrators are appointed by the Solid Director. Administrators are listed at [administrators.md](administrators.md) along with their contact details and affiliations. Anyone may apply to be an Administrator. Administrator applications are not reviewed by other Administrators. They are reviewed only by the Solid Director.
-
 # Solidproject.org Website 
-
-The [Creators](https://github.com/solid/process/blob/master/creators.md) are responsible for creating content for the solidproject.org website. 
-
-[Creators](https://github.com/solid/process/blob/master/creators.md) are appointed by the Solid Director.
-
-[Creators](https://github.com/solid/process/blob/master/creators.md) have [_Admin Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) of the [solidproject.org](https://github.com/solid/solidproject.org), [information](https://github.com/solid/information) , [Solid app listing](https://github.com/solid/solid-apps), [Pod listing](https://github.com/solid/pods), and [identity listing](https://github.com/solid/solid-idp-list),[explaining the vision](https://github.com/solid/Explaining-the-Vision-Panel) repositories.
 
 The solidproject.org website is linked to the [`master` branch of the GitHub repo solid/solidproject.org](https://github.com/solid/solidproject.org/tree/master). Draft versions of updates of the website are worked on in the [`staging` branch of the same repo](https://github.com/solid/solidproject.org/tree/staging). The draft work is documented on the [Creators project board](https://github.com/orgs/solid/projects/12). 
 
@@ -97,11 +139,10 @@ Anyone can make suggestions by commenting or submitting  pull requests to the [`
 Spelling, grammar, broken links, and other minor changes do not need to be approved by the Solid Director and can be updated directly by the Creators. 
 
 # This Week in Solid
-[This Week in Solid](https://solidproject.org/this-week-in-solid) is a newsletter [openly developed on GitHub](https://github.com/solid/solidproject.org/blob/staging/_posts/this-week-in-solid/next.md). If you would like something to be mentioned or find any errors in a previous edition please [submit a pull request](https://github.com/solid/solidproject.org/pulls). [This Week in Solid](https://solidproject.org/this-week-in-solid) is sent via the mailing list every Thursday at 1500 CET by Administrators after being edited and reviewed by the Director.
+[This Week in Solid](https://solidproject.org/this-week-in-solid) is a newsletter [openly developed on GitHub](https://github.com/solid/solidproject.org/blob/staging/_posts/this-week-in-solid/next.md). If you would like something to be mentioned or find any errors in a previous edition please [submit a pull request](https://github.com/solid/solidproject.org/pulls). [This Week in Solid](https://solidproject.org/this-week-in-solid) is sent via the mailing list every Thursday at 1500 CET by the Manager. 
 
 # References
-
-Solid culture documentation was put together with inspiration and learnings from the following resources.
+The Solid Process respository was put together with inspiration and learnings from the following resources.
 
 * [W3C Good practice for running a group](https://www.w3.org/community/about/good-practice-for-running-a-group/)
 * Python (2018) [Python Language](https://www.python.org/dev/peps/pep-0013/)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ This repository details how changes to [Solid](https://github.com/solid/specific
 
 Anyone may participate in [this process](https://github.com/solid/process). Please read the [Code of Conduct](code-of-conduct.md) before doing so.
 
+To apply for a role you can either submit a pull request to the corresponding .md file in the Process repository or send an email to info@solidproject.org with your CV and motivation letter.
+
 Anyone may submit a proposal to alter this process. These proposals will not be reviewed by the editors. They will be reviewed only by [Tim Berners-Lee](https://github.com/timbl), who is the Solid Director.
 
 ## Roles
@@ -118,11 +120,16 @@ Any proposal should also be accompanied with a reasonable explanation of the nee
 - Removing something because it was never adopted by Implementers for legitimate reasons, or because there has been a collective shift in focus away from that feature and it no longer makes sense to keep it.
 - Changing something to a simpler design that is able to address the same use case(s) with less complexity, or a change that resolves one or more identified issues in real-world use.
 
-To submit a proposal for editorial review any panllist may open a [pull request to the Solid repository](https://github.com/solid/specification/pulls) which clearly links to the issue where the proposal was discussed. The pull request needs to be left open for seven days to give over panellists a chance to suggest improvements. Seven days after the pull request was opened it's ready for editorial review.  
+To submit a proposal for editorial review any panllist may open a [pull request to the Solid repository](https://github.com/solid/specification/pulls) which clearly links to the issue where the proposal was discussed. The pull request needs to be left open for seven days to give over panellists a chance to suggest improvements. 
+
+Seven days after the [pull request](https://github.com/solid/specification/pulls) was opened it's ready for editorial review. One of the panellists has to post it to the [gitter channel](https://gitter.im/solid/specification) and tag all the [Editors](https://github.com/solid/process/blob/master/editors.md).   
+
+One Editor listed as being an expert on the Solid Topic to which the issues and pull requests are labelled should be assigned. That Editor is responsible for ensuring that the issue or pull request is included in the appropriate milestone and Editor weekly calls. 
 
 ### Reviewing proposals
 
 Candidate proposals to [Solid](https://github.com/solid/specification) submitted for editorial review go through an editorial process before they are accepted.
+
 
 An Editor determines whether a Candidate Proposal includes a substantive change and marks it accordingly with a label. If there is any disagreement among Editors, the Candidate Proposal will be automatically marked as including a substantive change.
 

--- a/README.md
+++ b/README.md
@@ -1,59 +1,58 @@
-This repository details how changes to Solid may be proposed and accepted.
+This repository details how changes to [Solid](https://github.com/solid/specification) may be proposed and accepted.
 
-# Solid Specification
-The following is a description about how changes to the [Solid Specification](https://github.com/solid/specification) may be proposed and accepted.
+Anyone may participate in [this process](https://github.com/solid/process). Please read the [Code of Conduct](code-of-conduct.md) before doing so.
 
-Anyone may participate in [this process](https://github.com/solid/culture). Please read the [Code of Conduct](code-of-conduct.md) before doing so.
+Anyone may submit a proposal to alter this process. These proposals will not be reviewed by the editors. They will be reviewed only by [Tim Berners-Lee](https://github.com/timbl), who is the Solid Director.
 
 ## Contributors
 
-Any individual that has been involved in proposals to improve the [Solid Specification](https://github.com/solid/specification) has provided a valuable service to the [Solid Project](https://www.solidproject.org) and is encouraged to continue.
+Any individual that has been involved in proposals to improve the [Solid](https://github.com/solid/specification) has provided a valuable service to the [Solid Project](https://www.solidproject.org) and is encouraged to continue.
 
 All manner of contributions are important - whether identifying problems, asking questions, or proposing normative changes.
 
-There are many topics, problems, or ideas best tackled by a group of people with a specific set of domain expertise. For these cases, we have [Solid Panels](#solid-panels).
+There are many problems and ideas best tackled by a group of people with a specific set of domain expertise called Solid Topics. All contributors are listed as having domain expertise on specific Solid Topics. 
 
-### Solid Panels
+### Panellists 
+A [Solid Panel](#solid-panels) is a group of individuals focused a specific Solid Topic with a defined aim. Solid Panels author proposals to change [Solid](https://github.com/solid/specification). 
 
-Solid Panels are groups of individuals focused on a specific problem or domain relevant to Solid, with an aim to propose changes to the [Solid Specification](https://github.com/solid/specification). Anyone may join a panel or suggest a new panel.
+Anyone may join a panel or suggest a new panel.
 
 Domains may be technical, non-technical, or some combination of the two. For example, a Security Panel could focus on the evaluation and advancement of the Solid security model.
 
 A list of Solid Panels is maintained at [panels.md](panels.md). This listing helps people find panels they may want to participate in, and helps editors find panels to consult as part of the editorial process.
 
-Panels may request to have a repository created within the [Solid Github Organization](https://github.com/solid). These requests should be made by submitting an issue to [solid/process](https://github.com/solid/process). The request should include the proposed name of the repository, and how it will be used. Any editor may reject a proposed name and request an alternative. All panel members will receive [_Maintain Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) on the panel repository, unless it is subject to editorial review, which would require that it employ a [different permission structure](#repositories). Panel repositories that are inactive for more than six months may be archived by Solid Administrators.
+Panels that are inactive for more than six months may be archived by Solid Administrators.
 
-Panels may request to have a gitter channel created within the [Solid Gitter Organization](https://gitter.im/solid). These requests should be made by submitting an issue to [solid/process](https://github.com/solid/process).
+Panellists belong to the [Panllist Team](https://github.com/orgs/solid/teams/panellists) in the [Solid GitHub Organization](https://github.com/solid).
 
-## Stakeholders
+### Editors 
+[Solid Editors](editors.md) are individuals who are collectively responsible for editing [Solid](https://github.com/solid/specification). 
 
-Stakeholders are those affected by normative changes to the [Solid Specification](https://github.com/solid/specification). There are two types of Stakeholders; [Solid Users](#solid-users) and [Solid Implementers](#solid-implementers). It is important to consider them both when proposing changes, and adhering to the W3C [priority of constituencies](https://www.w3.org/TR/html-design-principles/#priority-of-constituencies) is encouraged. A Stakeholder may be both a user and an implementer.
+Editor appointments and their respective assignments to a specific Solid Topic are made by the Solid Director. The Editorial Team is comprised of all the Editors appointed by the Solid Director, who are listed at [editors.md](editors.md), along with their Solid Topic, contact details, and affiliations. Anyone may apply to be an Editor, and must include one or more requested Solid Topics as part of their application. These requests are not reviewed by other Editors. They are reviewed only by the Solid Director. Editor applications that can demonstrate the support of a relevant panel or group of community members will be favorably considered.
 
-Stakeholders who have opted to identify themselves publicly are listed at [stakeholders.md](stakeholders.md). Anyone may decide to identify themselves publicly as a Solid Stakeholder, but it is not mandatory. Identified stakeholders may be consulted for feedback as part of the editorial process.
+Editors belong to the [Editorial Team](https://github.com/orgs/solid/teams/editors) in the [Solid GitHub Organization](https://github.com/solid).
 
-### Solid Users
+Editors have [Admin Permissions](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) of the [Solid repository](https://github.com/solid/specification). 
 
-Solid Users are individuals, companies, or organizations who access data stored in a Solid Pod.
+## How to Make Changes to [Solid](https://github.com/solid/specification)
 
-### Implementers
-Solid Implementers are companies or organizations who are implementing the [Solid Specification](https://github.com/solid/specification). A Solid Implementer may be any combination of Identity Provider, Pod Provider, and Application Provider.
-
-## How to Make Changes
-
-This section details how changes to the [Solid Specification](https://github.com/solid/specification) may be drafted, proposed, and accepted.
-
-Anyone may submit a proposal to alter this process. These proposals will not be reviewed by the editors. They will be reviewed only by [Tim Berners-Lee](https://github.com/timbl), who is the Solid Director.
+This section details how changes to the [Solid](https://github.com/solid/specification) may be drafted, submitted, and accepted.
 
 ### Drafting proposals
 
-Anyone may propose improvements to the [Solid Specification](https://github.com/solid/specification). Here are some examples of different ways to contribute:
+Anyone may propose improvements to the [Solid](https://github.com/solid/specification). 
 
-- Submit a pull request or issue on the [Solid Specification repository](https://github.com/solid/solid-spec) in GitHub
-- Make a suggestion to the Solid Authorization Panel chat room about a change you'd like to see in Web Access Control
-- Make a suggestion on the Solid W3C Community Group mailing list to form a new Solid Panel, or join an existing Solid Panel
-- Propose an item for the W3C Solid Community Group call
+Panellists work in [issues in the Solid repository](https://github.com/solid/specification/issues) which need to have a Solid Topic label indicating which panel is working it. Editors are responsible for ensuring that every issue in the [Solid repository](https://github.com/solid/specification) has a Solid Topic label.
 
-Proposals for substantive changes to the [Solid Specification](https://github.com/solid/specification) go through an editorial review process. A change is considered substantive when it alters the normative text of the Solid Specification or the Solid Roadmap. Any proposal must be realistic and reasonable to implement, preferably with example implementations, and demonstrable support from Implementers.
+Communication should be concentrated on issues and pull requests on the Solid repository and not on [Solid gitter channels]((https://gitter.im/solid)) or sepearte repositories to make sure that everyone can keep track of all the relevant conversations. 
+
+On the 19th of every month there is a predefined [milestone](https://github.com/solid/specification/milestones) which includes all the issues and pull requests that are being worked on. The title of each pull request or issue needs to clearly define the exact required outcome. 
+
+Anyone can suggest which issues and pull reqeusts should be included in the upcoming milestone by writting a note in the  [gitter channel](https://gitter.im/solid/specification) including a link to the issue or pull request. The Solid Director approves the next milestone on the 19th. 
+
+### Submitting proposals
+
+Proposals for substantive changes to the [Solid](https://github.com/solid/specification) go through an editorial review process. A change is considered substantive when it alters the normative text of the Solid. Any proposal must be realistic and reasonable to implement, preferably with example implementations, and demonstrable support from Implementers.
 
 Any proposal should also be accompanied with a reasonable explanation of the need for the proposed change. For example:
 
@@ -61,32 +60,17 @@ Any proposal should also be accompanied with a reasonable explanation of the nee
 - Removing something because it was never adopted by Implementers for legitimate reasons, or because there has been a collective shift in focus away from that feature and it no longer makes sense to keep it.
 - Changing something to a simpler design that is able to address the same use case(s) with less complexity, or a change that resolves one or more identified issues in real-world use.
 
-A draft proposal often involves public discussion before being formally presented for review. After these discussions have occurred and a draft proposal has reached a sufficient level of maturity, it should be presented as a candidate proposal, asking Stakeholders and Panels if there are any major objections.
-
-When there are objections, notify the Solid Panels and Stakeholders about the final proposal with an invitation to vote. If there are options, detail them along with the implications of the options. The final proposal needs to be open for one week to give others a chance to vote. To show your support for a proposal write +1. To show your disapproval for a proposal write -1 along with a detailed reason for the disapproval and a suggestion for a preferred alternative. To abstain type 0 when you have no opinion. If you do not vote by the end of the week it will be assumed that you abstain. At the end of the week anyone may publish an overview of the vote results per Solid Panel and Stakeholder.
+To submit a proposal for editorial review any panllist may open a [pull request to the Solid repository](https://github.com/solid/specification/pulls) which clearly links to the issue where the proposal was discussed. The pull request needs to be left open for seven days to give over panellists a chance to suggest improvements. Seven days after the pull request was opened it's ready for editorial review.  
 
 ### Reviewing proposals
 
-Candidate proposals to the [Solid Specification](https://github.com/solid/specification) submitted for review go through an editorial process before they are accepted.
-Candidate Proposals to change the Solid Specification must be submitted for editorial review before they are accepted, along with the results of any votes taken.
+Candidate proposals to [Solid](https://github.com/solid/specification) submitted for editorial review go through an editorial process before they are accepted.
 
-An Editor determines whether a Candidate Proposal includes a substantive change and marks it accordingly. If there is any disagreement among Editors, the Candidate Proposal will be automatically marked as including a substantive change.
+An Editor determines whether a Candidate Proposal includes a substantive change and marks it accordingly with a label. If there is any disagreement among Editors, the Candidate Proposal will be automatically marked as including a substantive change.
 
 Candidate Proposals with substantive changes require three Editors who are assigned to the material being modified to actively approve the proposal, with no Editors from the Editorial Team actively rejecting. If there are less than three Editors assigned to the material being modified, then other Editors from the Editorial Team may participate.  Editors may abstain. Candidate Proposals with substantive changes must remain open for at least one week before final acceptance. If an Editor does not vote by the end of that week it will be assumed that they abstained, providing a good faith attempt has been made to involve those who may be likely to disagree. Once the Candidate Proposal has successfully passed editorial review and the specified wait-time has elapsed, it may be merged by an assigned Editor.
 
 Candidate Proposals without substantive changes require one Editor assigned to the material being modified to actively approve the proposal, with no Editors from the Editorial Team actively rejecting, and may be merged immediately by an assigned Editor. An assigned Editor may approve and merge their own non-substantive changes. Anyone from the Editorial Team has the right to revert a non-substantive change, but are encouraged to communicate with the assigned Editor that merged it first. Any revert must be accompanied by a reasonable explanation. If the change is reverted because they believe it to be substantive, that must be included in the explanation.
-
-## Editorial Structure
-
-Editor appointments and their respective assignments are made by the Solid Director. The Editorial Team is comprised of all the Editors appointed by the Solid Director, who are listed at [editors.md](editors.md), along with their assignments, contact details, and affiliations. Anyone may apply to be an Editor, and must include one or more requested editorial assignments as part of their application. These requests are not reviewed by other Editors. They are reviewed only by the Solid Director. Editor applications that can demonstrate the support of a relevant panel or group of community members will be favorably considered.
-
-Editors belong to the [Editorial Team](https://github.com/orgs/solid/teams/editors) in the [Solid GitHub Organization](https://github.com/solid).
-
-### Repositories
-
-Repositories requiring editorial review are listed in [editors.md](editors.md#editorial-assignments). Each repository has one or more assigned editors, and only assigned editors are permitted to merge into the master branch of these repositories, per the [proposal review process](#reviewing-proposals).
-
-Editors have [_Admin Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) on the repositories they are assigned to, and are permitted to grant [_Write Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) to other contributing authors on the same. All members of the Editorial Team have [_Write Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) on all repositories requiring editorial review listed in [editors.md](editors.md).
 
 # Administration
 
@@ -111,6 +95,9 @@ The solidproject.org website is linked to the [`master` branch of the GitHub rep
 Anyone can make suggestions by commenting or submitting  pull requests to the [`staging` branch of solid/solidproject.org](https://github.com/solid/solidproject.org/tree/staging) to be reviewed by Creators, and be approved by the Solid Director before they go to `master`.
 
 Spelling, grammar, broken links, and other minor changes do not need to be approved by the Solid Director and can be updated directly by the Creators. 
+
+# This Week in Solid
+[This Week in Solid](https://solidproject.org/this-week-in-solid) is a newsletter [openly developed on GitHub](https://github.com/solid/solidproject.org/blob/staging/_posts/this-week-in-solid/next.md). If you would like something to be mentioned or find any errors in a previous edition please [submit a pull request](https://github.com/solid/solidproject.org/pulls). [This Week in Solid](https://solidproject.org/this-week-in-solid) is sent via the mailing list every Thursday at 1500 CET by Administrators after being edited and reviewed by the Director.
 
 # References
 


### PR DESCRIPTION
Following the 19th December 2019 deadline of the [milestone](https://github.com/solid/specification/milestone/1) there was a gap analysis that happened on an [issue](https://github.com/solid/specification/issues/134) as well as on a two W3C Solid Community Group calls in both timezones. The minutes for the [20200102_1600CET](https://www.w3.org/community/solid/wiki/Meetings#20200102_1600CET) and [20200109_1000CET](https://www.w3.org/community/solid/wiki/Meetings#20200109_1000CET) were recorded for reference. 

In this pull request, I have started to incorporate the suggestions from the conversations into a process proposal. 

I'm still working on including a few more details but will publish the work so far so we can co-create and include any suggestions along the way.