### PR TITLE
Add medium-weight review for medium-sized changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The solidproject.org website is linked to the [`master` branch of the GitHub rep
 
 Anyone can make suggestions by commenting or submitting  pull requests to the [`staging` branch of solid/solidproject.org](https://github.com/solid/solidproject.org/tree/staging) to be reviewed by Creators, and be approved by the Solid Director before they go to `master`.
 
-Spelling, grammar, broken links, and other minor changes do not need to be approved by the Solid Director and can be updated directly by the Creators. 
+Spelling, grammar, broken links, and other minor changes do not need to be approved by the Solid Director and can be updated directly by the Creators. Changes larger than that, but that do not significantly alter the website content (such as referencing community activity outside of the website) also do not need to be approved by the Solid Director, as long as they have been approved by one of the [Editors](https://github.com/solid/process/blob/master/editors.md).
 
 # References
 


### PR DESCRIPTION
An editor voiced concerns that some of the smaller updates to solidproject.org (such as publication of This Week in Solid) might include technical inaccuracies, and requested those to also be reviewed by an editor. This PR formalises that.

Of course, this does require editors to review those changes within a reasonable time frame. If, in the weeks after accepting this proposal, that proves not to be achievable, we will want to revise this again to see how we can streamline that - but for now, I propose we just wait and see how this plays out.