### PR TITLE
De-list inactive panels for now

### DIFF
--- a/panels.md
+++ b/panels.md
@@ -23,25 +23,9 @@ Candidate Proposals to the Solid Specification produced by this panel are likely
 
 ## Index of Panels
 
-* [Accessibility](#accessibility)
-* [Auditing](#auditing)
-* [Authorization and Access Control](#authorization-and-access-control)
-* [Artificial Intelligence](#artificial-intelligence)
+* [Authorisation](#authorisation)
 * [Authentication](#authentication)
-* [Caching](#caching)
-* [Cryptography, Security, and Privacy](#cryptography-security-and-privacy)
-* [Data Interoperability and Portability](#data-interoperability-and-portability)
-* [Events and Notifications](#events-and-notifications)
-* [Explaining the Vision](#explaining-the-vision)
-* [External Interop and Outreach](#external-interop-and-outreach)
-* [Identity](#identity)
-* [Internationalisation](#internationalisation)
-* [Resource Access](#resource-access)
-* [Privacy and Individuals Rights Protection](#privacy-and-individuals-rights-protection-panel)
-* [Query](#query)
-* [Self Hosting](#self-hosting)
-* [Specification Entry Document](#specification-entry-document-panel)
-* [User Lifecycle](#user-lifecycle)
+* [Interoperability](#interoperability)
 
 All Panels can be reached on [public-solid@w3.org](https://lists.w3.org/Archives/Public/public-solid/)
 
@@ -49,33 +33,7 @@ There is a weekly W3C Solid Community Group call to review all panels on Thursda
 
 You can also read weekly updates of all panels on [This Week in Solid](https://github.com/solid/information/blob/master/weekly-updates/this-week-in-solid.md).
 
-## Accessibility
-How to ensure that the technical decisions are taking accessibility considerations into account.
-
-### Communication channels
-- [accessibility panel repository](https://github.com/solid/Accessibility-Panel)
-
-### Panelists
-- [Sina Bahram](https://github.com/sinabahram) <[sina@sinabahram.com](mailto:sina@sinabahram.com)> (@sinabahram)
-- [Bud](https://github.com/spudthebud) (@spudthebud)
-- [elf Pavlik](https://github.com/elf-pavlik) <[elf-pavlik@hackers4peace.net](mailto:elf-pavlik@hackers4peace.net)> (@elf-pavlik)
-
-### Editorial Assignment 
-*currently none* 
-
-## Auditing Panel
-Pertaining to the mechanisms through which access and manipulation events of resources in a data pod are recorded and accessible.
-
-### Communication channels
-- 
-
-### Panelists
-- 
-
-### Editorial Assignment 
-Candidate Proposals to the Solid Specification produced by this panel are likely to be associated with the [Auditing Editorial Assignment](https://github.com/solid/process/blob/master/editors.md#auditing), and will be principally reviewed by any editors assigned to it.
-
-## Authorization and Access Control
+## Authorisation 
 How various agents and authorized to access resources.
 
 ### Communication channels
@@ -95,18 +53,6 @@ How various agents and authorized to access resources.
 
 ### Editorial Assignment 
 Candidate Proposals to the Solid Specification produced by this panel are likely to be associated with the [Authorization editorial topic](https://github.com/solid/process/blob/master/editors.md#authorization), and will be principally reviewed by any editors assigned to it.
-
-## Artificial Intelligence
-To discuss Artificial Intelligence for Solid
-
-### Communication channels
-- [artificial intelligence panel repository](https://github.com/solid/Artificial-Intelligence-Panel)
-
-### Panelists
-* [James Schoening](https://github.com/jimschoening) <[james.r.schoening.civ@mail.mil](mailto:james.r.schoening.civ@mail.mil)> (@jimschoening)
-
-### Editorial Assignment 
-*currently none* 
 
 ## Authentication
 Discussion and specs relating to Authentication and Auth Delegation protocols, including:
@@ -137,47 +83,7 @@ Discussion and specs relating to Authentication and Auth Delegation protocols, i
 ### Editorial Assignment 
 Candidate Proposals to the Solid Specification produced by this panel are likely to be associated with the [Authentication editorial topic](https://github.com/solid/process/blob/master/editors.md#authentication), and will be principally reviewed by any editors assigned to it.
 
-## Caching
-Ensure that caching mechanisms, both currently standardized and future standards are employed within Solid.
-
-### Communication channels
-- [caching panel repository](https://github.com/solid/caching-panel)
-
-### Panelists
-- [Kjetil Kjernsmo](https://github.com/orgs/solid/people/kjetilk) <[kjetil@inrupt.com](mailto:kjetil@inrupt.com)> (@kjetilk)
-
-### Editorial Assignment 
-*currently none* 
-
-## Cryptography, Security, and Privacy
-Discussion and specs related to performing decentralized Key Management, Cryptographic Signatures (including integration with [Verifiable Credentials](https://w3c.github.io/vc-data-model/)), and at-rest data Encryption on Solid servers. Pertaining to mechanisms used and considerations taken when securing a data pod, a conformant server implementation, and/or the immediate ecosystem around them.  Pertaining to the mechanisms through which cryptographic techniques are employed to provide data privacy, data integrity, and verifiable information. The focus of this panel is to ensure Privacy is always kept in mind in the various proposals of the project across all panels, and that individuals' rights are inherently protected in the Solid ecosystem. It will do so by:
-- Leading Privacy discussions and initiatives.
-- Reviewing the proposals of other panels for anything Privacy related, and provide guidance to them if requested.
-- Researching how the technical side of the project (specification, implementations):
-  - Can affect the Privacy of individuals; Per example by unexpectedly leaking information in the protocol itself.
-  - Affect their rights; Per example by making it difficult for them to find privacy policies or delete remote content.
-  - Lead to any kind of harm to the individual; Per example, by allowing a malicious individual to publish private content unchecked.
-- Ensuring practical guides are produced for individuals and Data Privacy Officers alike, allowing them to know how to deal with their legal rights and obligations respectively.
-- Making sure laws like GDPR are directly taken into account when designing new feature / product / software.
-
-### Communication channels
-- [Cryptography, Security, and Privacy Panel Repository](https://github.com/solid/cryptography-signing-privacy)
-- [gitter channel](https://gitter.im/solid/cryptography-signing-privacy)
-
-### Panelists
-- [Dmitri Zagidulin](https://github.com/dmitrizagidulin) <[dzagidulin@gmail.com](mailto:dzagidulin@gmail.com)> (@dmitrizagidulin)
-- [Paul Worrall](https://github.com/pjworrall) <[paulw@inrupt.com](mailto:paulw@inrupt.com)> (@pjworrall)
-- [Justin Bingham](https://github.com/justinwb) <[justin.bingham@janeirodigital.com](mailto:justin.bingham@janeirodigital.com)> (@justinwb)
-- [Kjetil Kjernsmo](https://github.com/orgs/solid/people/kjetilk) <[kjetil@inrupt.com](mailto:kjetil@inrupt.com)> (@kjetilk)
-- [Rob McColl](https://github.com/robmccoll) <[rob@nix.software](mailto:rob@nix.software)> (@robmccoll)
-- [Max Dor](https://github.com/maxidorius) <[max@dorius.io](mailto:max@dorius.io)> (@maxidorius)
-- [Henry Story](http://github.com/bblfish) <[henry.story@bblfish.net](mailto:henry.story@bblfish.net)> (@bblfish)
-- [Sarven Capadisli](https://github.com/csarven) &lt;https://csarven.ca/#i&gt; (@csarven)
-
-### Editorial Assignment 
-Candidate Proposals to the Solid Specification produced by this panel are likely to be associated with the [Security, Cryptography, and Privacy editorial assignment](https://github.com/solid/process/blob/master/editors.md#cryptography-security-and-privacy), and will be principally reviewed by any editors assigned to it.
-
-## Data Interoperability and Portability
+## Interoperability
 Ensuring the interoperability of data as it is read and written by different users and/or applications. Topics of discussion will include vocabularies, shapes, footprints, and the mechanisms through which these work together to provide consistent and safe access and manipulation of data in a pod by different agents and/or users. Pertaining to mechanisms that ensure disparate applications or agents can safely and seamlessly read and write the data they need.  Pertaining to mechanisms that ensure the portability of data stored in a data pod such that it can be safely migrated between conformant Solid server implementations, as well as exported to other mediums.  
 
 ### Communication channels
@@ -203,165 +109,4 @@ Ensuring the interoperability of data as it is read and written by different use
 ### Editorial Assignment 
 Candidate Proposals to the Solid Specification produced by this panel are likely to be associated with the [Data Interoperability and Portability editorial topic](https://github.com/solid/process/blob/master/editors.md#data-interoperability-and-portability), and will be principally reviewed by any editors assigned to it.
 
-## Events and Notifications
-Pertaining to mechanisms that process and/or emit events between pods and agents, or other pods. Development of mechanisms to shape and exchange notifications.Development of mechanisms to shape and exchange notifications.
 
-### Communication channels
-- [notifications-panel repository](https://github.com/solid/notifications-panel)
-
-### Panelists
-- [Sarven Capadisli](https://github.com/csarven) &lt;https://csarven.ca/#i&gt; (@csarven)
-- [Ruben Verborgh](https://github.com/RubenVerborgh) <[Ruben.Verborgh@UGent.be](mailto:Ruben.Verborgh@UGent.be)>(@RubenVerborgh)
-- [Justin Bingham](https://github.com/justinwb) <[justin.bingham@janeirodigital.com](mailto:justin.bingham@janeirodigital.com)> (@justinwb)
-- [Dmitri Zagidulin](https://github.com/dmitrizagidulin) <[dzagidulin@gmail.com](mailto:dzagidulin@gmail.com)> (@dmitrizagidulin)
-
-### Editorial Assignment 
-Candidate Proposals to the Solid Specification produced by this panel are likely to be associated with the [Events and Notifications editorial topic](https://github.com/solid/process/blob/master/editors.md#events-and-notifications), and will be principally reviewed by any editors assigned to it.
-
-## Explaining the Vision
-Taking the suggestions on the channels listed below to produce proposals explaining [what is Solid](https://github.com/solid/roadmap/blob/master/what-is-solid.md) and the [Solid vision, mission, and values](https://github.com/solid/roadmap/blob/master/solid-mission-vision-values.md). 
-Related conversations to take into consideration: 
-* https://github.com/solid/information/pull/202
-* https://github.com/solid/information/issues/180 
-* https://github.com/solid/roadmap/pull/1
-* https://github.com/solid/roadmap/pull/3
-* https://github.com/solid/roadmap/pull/4
-* https://github.com/solid/roadmap/pull/5
-* https://github.com/solid/roadmap/pull/6
-* https://github.com/solid/roadmap/pull/7
-* https://github.com/solid/roadmap/pull/8
-* https://github.com/solid/roadmap/pull/9
-
-### Communication channels
-- [GitHub team discussion board](https://github.com/orgs/solid/teams/explaining-the-vision-panel/discussions)
-- [Explaining the Visions Solid Github Repository](https://github.com/solid/Explaining-the-Vision-Panel) 
-- most conversation about "What is Solid" is here https://github.com/solid/Explaining-the-Vision-Panel/issues/1#issuecomment-518300433
-
-### Panelists
-- [James Schoening](https://github.com/jimschoening) <[james.r.schoening.civ@mail.mil](mailto:james.r.schoening.civ@mail.mil)> (@jimschoening)
-- [Dan Wilkinson](https://github.com/danwilkinsoncreative) <[dan@get-even.co.uk](mailto:dan@get-even.co.uk)> (@danwilkinsoncreative)
-- [Paul Worrall](https://github.com/pjworrall) <[paulw@inrupt.com](mailto:paulw@inrupt.com)> (@pjworrall)
-- [Ruben Verborgh](https://github.com/RubenVerborgh) <[Ruben.Verborgh@UGent.be](mailto:Ruben.Verborgh@UGent.be)>(@RubenVerborgh)
-- [Justin Bingham](https://github.com/justinwb) <[justin.bingham@janeirodigital.com](mailto:justin.bingham@janeirodigital.com)> (@justinwb)
-- [Kjetil Kjernsmo](https://github.com/orgs/solid/people/kjetilk) <[kjetil@inrupt.com](mailto:kjetil@inrupt.com)> (@kjetilk)
-- [Sarven Capadisli](https://github.com/csarven) &lt;https://csarven.ca/#i&gt; (@csarven)
-
-### Editorial Assignment 
-*currently none* 
-
-## External Interop and Outreach
-How to technically link to other initiatives to build positive win-win collaborations. 
-
-### Communication channels
-- [external-interop repository](https://github.com/solid/external-interop)
-
-### Panelists
-- [Dmitri Zagidulin](https://github.com/dmitrizagidulin) <[dzagidulin@gmail.com](mailto:dzagidulin@gmail.com)> (@dmitrizagidulin)
-- [David H. Mason](https://github.com/vid) <[vid_github_solid_outreach@zooid.org](mailto:vid_github_solid_outreach@zooid.org)> (@vid)
-
-### Editorial Assignment 
-*currently none* 
-
-## Identity
-Discussions and specs for expanding the capabilities of Solid's WebID identity system, including user profiles, [Decentralized Identifiers (DIDs)](https://w3c-ccg.github.io/did-spec/), and related standards.
-
-### Communication channels
-- [identity panel repository](https://github.com/solid/identity-panel) 
-
-### Panelists
-- [Dmitri Zagidulin](https://github.com/dmitrizagidulin) <[dzagidulin@gmail.com](mailto:dzagidulin@gmail.com)> (@dmitrizagidulin)
-- [Paul Worrall](https://github.com/pjworrall) <[paulw@inrupt.com](mailto:paulw@inrupt.com)> (@pjworrall)
-- [Justin Bingham](https://github.com/justinwb) <[justin.bingham@janeirodigital.com](mailto:justin.bingham@janeirodigital.com)> (@justinwb)
-- [Henry Story](http://github.com/bblfish) <[henry.story@bblfish.net](mailto:henry.story@bblfish.net)> (@bblfish)
-
-### Editorial Assignment 
-Candidate Proposals to the Solid Specification produced by this panel are likely to be associated with the [Identity editorial topic](https://github.com/solid/process/blob/master/editors.md#identity), and will be principally reviewed by any editors assigned to it.
-
-## Internationalisation
-To ensure internationalisation is taken into consideration during the Solid design.
-
-### Communication channels
-- [internationalisation panel repository](https://github.com/solid/internationalisation-panel)
-
-### Panelists
-- [King Wang](https://github.com/kingwang88) <[kingwang@hsfranchise.com](mailto:kingwang@hsfranchise.com)> (@kingwang88)
-- [Philip Laszkowicz](https://github.com/HelloFillip) <[phil@fillip.pro](mailto:phil@fillip.pro)> (@HelloFillip)
-- [elf Pavlik](https://github.com/elf-pavlik) <[elf-pavlik@hackers4peace.net](mailto:elf-pavlik@hackers4peace.net)> (@elf-pavlik)
-
-### Editorial Assignment 
-*currently none* 
-
-## Resource Access
-Pertaining to the access of resources in a data pod over a network via HTTP and LDP
-
-### Communication channels
-- 
-
-### Panelists
-- 
-### Editorial Assignment 
-Candidate Proposals to the Solid Specification produced by this panel are likely to be associated with the [Resource Access](https://github.com/solid/process/blob/master/editors.md#resource-access), and will be principally reviewed by any editors assigned to it.
-
-## Query
-Discussion, specs and recommendations for implementing querying mechanisms beyond LDP, such as SPARQL, [Triple Pattern Fragments (TPF)](http://linkeddatafragments.org/in-depth/), GraphQL, and others.
-
-### Communication channels
-- [Query Panel Repository](https://github.com/solid/query-panel) 
-- [Query Panel Gitter](https://gitter.im/solid/query-panel?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
-### Panelists
-- [Dmitri Zagidulin](https://github.com/dmitrizagidulin) <[dzagidulin@gmail.com](mailto:dzagidulin@gmail.com)> (@dmitrizagidulin)
-- [Aaron Coburn](https://github.com/acoburn) <[aaronc@inrupt.com](mailto:aaronc@inrupt.com)> (@acoburn)
-- [Ruben Verborgh](https://github.com/RubenVerborgh) <[Ruben.Verborgh@UGent.be](mailto:Ruben.Verborgh@UGent.be)>(@RubenVerborgh)
-- [Kjetil Kjernsmo](https://github.com/orgs/solid/people/kjetilk) <[kjetil@inrupt.com](mailto:kjetil@inrupt.com)> (@kjetilk)
-- [Jeff Zucker](https://github.com/jeff-zucker) <[dubzed@gmail.com](mailto:dubzed@gmail.com)> (@jeff-zucker)
-- [Justin Bingham](https://github.com/justinwb) <[justin.bingham@janeirodigital.com](mailto:justin.bingham@janeirodigital.com)> (@justinwb)
-- [Travis Vachon](https://github.com/travis) <[travis.vachon@gmail.com](mailto:travis.vachon@gmail.com)> (@travis)
-
-### Editorial Assignment 
-Candidate Proposals to the Solid Specification produced by this panel are likely to be associated with the [Querying editorial topic](https://github.com/solid/process/blob/master/editors.md#querying), and will be principally reviewed by any editors assigned to it.
-
-## Self Hosting Panel
-Develop clarity on how to self-host and remain interoperable with other Pod providers. 
-
-### Communication channels
-- [Self Hosting Panel Repository](https://github.com/solid/self-hosting-panel)
-
-### Panelists
-- Danny Haider
-
-### Editorial Assignment 
-*currently none* 
-
-## Specification Entry Document Panel
-To create a structure for the document at https://github.com/solid/specification/, and the division in documents it links to and well as translating the community consensus regarding the application of the specifications mentioned in this document into a clear, unambiguous and implementable text.
-
-### Communication channels
-- [Issues on the Solid specification repository](https://github.com/solid/specification/)
-
-### Panelists
-- [Ruben Verborgh](https://github.com/RubenVerborgh) <[Ruben.Verborgh@UGent.be](mailto:Ruben.Verborgh@UGent.be)>(@RubenVerborgh)
-- [Kjetil Kjernsmo](https://github.com/orgs/solid/people/kjetilk) <[kjetil@inrupt.com](mailto:kjetil@inrupt.com)> (@kjetilk)
-- [Sarven Capadisli](https://github.com/csarven) &lt;https://csarven.ca/#i&gt; (@csarven)
-- [Justin Bingham](https://github.com/justinwb) <[justin.bingham@janeirodigital.com](mailto:justin.bingham@janeirodigital.com)> (@justinwb)
-- [King Wang](https://github.com/kingwang88) <[kingwang@hsfranchise.com](mailto:kingwang@hsfranchise.com)> (@kingwang88)
-
-### Editorial Assignment 
-*currently none* 
-
-### Editorial Assignment 
-Candidate Proposals to the Solid Specification produced by this panel are likely to be associated with the [general editors](https://github.com/solid/process/blob/master/editors.md#editorial-team), and will be principally reviewed by any editors.
-
-
-## User Lifecycle
-To build Solid-based APIs for registering, commissioning, recovery, deleting and managing users and their Pods.
-
-### Communication channels
-- [User Lifecycle panel repository](https://github.com/solid/user-lifecycle-panel)
-
-### Panelists
-- [Kjetil Kjernsmo](https://github.com/orgs/solid/people/kjetilk) <[kjetil@inrupt.com](mailto:kjetil@inrupt.com)> (@kjetilk)
-- [Nicolas Seydoux](https://github.com/orgs/solid/people/NSeydoux) <[nseydoux@inrupt.com](mailto:nseydoux@inrupt.com)> (@NSeydoux)
-
-### Editorial Assignment
-*currently none*

--- a/panels.md
+++ b/panels.md
@@ -15,31 +15,31 @@ This is an example that people can use as a template for submitting their own pa
 - Any other public communication link goes here
 
 ### Panelists
-- [Panellist Name](link to github profile) <[email@example.org](mailto:email@example.org)> (@github handle)
-- [Panellist Name](link to github profile) <[email@example.org](mailto:email@example.org)> (@github handle)
+- [Panelist Name](link to github profile) <[email@example.org](mailto:email@example.org)> (@github handle)
+- [Panelist Name](link to github profile) <[email@example.org](mailto:email@example.org)> (@github handle)
 
-### Editorial Assignment 
+### Editorial Assignment
 Candidate Proposals to the Solid Specification produced by this panel are likely to be associated with the [Editorial Assignment Name](https://github.com/solid/process/blob/master/editors.md#insert-editorial-assignment-link), and will be principally reviewed by any editors assigned to it.
 
 ## Index of Panels
 
-* [Authorisation](#authorisation)
+* [Authorization](#authorization)
 * [Authentication](#authentication)
 * [Interoperability](#interoperability)
 
 All Panels can be reached on [public-solid@w3.org](https://lists.w3.org/Archives/Public/public-solid/)
 
-There is a weekly W3C Solid Community Group call to review all panels on Thursdays alternating between 1000CEST and 1600CEST on https://zoom.us/j/121552099. See [here](https://www.w3.org/community/solid/wiki/Meetings) to read the minutes of previous calls, find out the agenda and exact time of the next call, or to add an item to the next agenda. 
+There is a weekly W3C Solid Community Group call to review all panels on Thursdays alternating between 1000CEST and 1600CEST on https://zoom.us/j/121552099. See [here](https://www.w3.org/community/solid/wiki/Meetings) to read the minutes of previous calls, find out the agenda and exact time of the next call, or to add an item to the next agenda.
 
 You can also read weekly updates of all panels on [This Week in Solid](https://github.com/solid/information/blob/master/weekly-updates/this-week-in-solid.md).
 
-## Authorisation 
+## Authorization
 How various agents and authorized to access resources.
 
 ### Communication channels
  - Wednesdays at 10AM Eastern at https://hangouts.google.com/call/vsPFdfBxsTgfHcjKbmcXAEEE
-- [app authorisation repository](https://github.com/solid/authorization-and-access-control-panel/issues/) 
-- [app authorisation gitter channel](https://gitter.im/solid/app-authorization-panel)
+- [app authorization repository](https://github.com/solid/authorization-and-access-control-panel/issues/)
+- [app authorization gitter channel](https://gitter.im/solid/app-authorization-panel)
 
 ### Panelists
 - [Dmitri Zagidulin](https://github.com/dmitrizagidulin) <[dzagidulin@gmail.com](mailto:dzagidulin@gmail.com)> (@dmitrizagidulin)
@@ -51,7 +51,7 @@ How various agents and authorized to access resources.
 - [Jamie Fiedler](https://github.com/jamiefiedler) <[j@jf.dev](mailto:j@jf.dev)> (@jamiefiedler)
 
 
-### Editorial Assignment 
+### Editorial Assignment
 Candidate Proposals to the Solid Specification produced by this panel are likely to be associated with the [Authorization editorial topic](https://github.com/solid/process/blob/master/editors.md#authorization), and will be principally reviewed by any editors assigned to it.
 
 ## Authentication
@@ -65,8 +65,8 @@ Discussion and specs relating to Authentication and Auth Delegation protocols, i
 
 ### Communication channels
 - Mondays at 10AM Eastern at https://hangouts.google.com/call/3k5z3gBVKm-58m8Xgm2YAEEE
-- [dedicated forum thread](https://forum.solidproject.org/t/authentication-panel/2086) 
-- [authentication panel repository](https://github.com/solid/authentication-panel) 
+- [dedicated forum thread](https://forum.solidproject.org/t/authentication-panel/2086)
+- [authentication panel repository](https://github.com/solid/authentication-panel)
 
 ### Panelists
 - [Dmitri Zagidulin](https://github.com/dmitrizagidulin) <[dzagidulin@gmail.com](mailto:dzagidulin@gmail.com)> (@dmitrizagidulin)
@@ -80,11 +80,11 @@ Discussion and specs relating to Authentication and Auth Delegation protocols, i
 - [Jamie Fiedler](https://github.com/jamiefiedler) <[j@jf.dev](mailto:j@jf.dev)> (@jamiefiedler)
 
 
-### Editorial Assignment 
+### Editorial Assignment
 Candidate Proposals to the Solid Specification produced by this panel are likely to be associated with the [Authentication editorial topic](https://github.com/solid/process/blob/master/editors.md#authentication), and will be principally reviewed by any editors assigned to it.
 
 ## Interoperability
-Ensuring the interoperability of data as it is read and written by different users and/or applications. Topics of discussion will include vocabularies, shapes, footprints, and the mechanisms through which these work together to provide consistent and safe access and manipulation of data in a pod by different agents and/or users. Pertaining to mechanisms that ensure disparate applications or agents can safely and seamlessly read and write the data they need.  Pertaining to mechanisms that ensure the portability of data stored in a data pod such that it can be safely migrated between conformant Solid server implementations, as well as exported to other mediums.  
+Ensuring the interoperability of data as it is read and written by different users and/or applications. Topics of discussion will include vocabularies, shapes, shape trees, and the mechanisms through which these work together to provide consistent and safe access and manipulation of data in a pod by different agents and/or users.
 
 ### Communication channels
 - [data-interoperability-repository](https://github.com/solid/data-interoperability-panel)
@@ -93,7 +93,7 @@ Ensuring the interoperability of data as it is read and written by different use
 - [Dmitri Zagidulin](https://github.com/dmitrizagidulin) <[dzagidulin@gmail.com](mailto:dzagidulin@gmail.com)> (@dmitrizagidulin)
 - [Justin Bingham](https://github.com/justinwb) <[justin.bingham@janeirodigital.com](mailto:justin.bingham@janeirodigital.com)> (@justinwb)
 - [Eric Prud'hommeaux](https://github.com/ericprud) <[eric@w3.org](mailto:eric@w3.org)> (@ericprud)
-- [Max Dor](https://github.com/maxidorius) <[max@dorius.io](mailto:max@dorius.io)> (@maxidorius) 
+- [Max Dor](https://github.com/maxidorius) <[max@dorius.io](mailto:max@dorius.io)> (@maxidorius)
 - [James Schoening](https://github.com/jimschoening) <[james.r.schoening.civ@mail.mil](mailto:james.r.schoening.civ@mail.mil)> (@jimschoening)
 - [Jose Emilio Labra Gayo](http://labra.weso.es) <[jelabra@gmail.com](mailto:jelabra@gmail.com)> (@labra)
 - [Ruben Verborgh](https://github.com/RubenVerborgh) <[Ruben.Verborgh@UGent.be](mailto:Ruben.Verborgh@UGent.be)>(@RubenVerborgh)
@@ -106,7 +106,5 @@ Ensuring the interoperability of data as it is read and written by different use
 - [Jamie Fiedler](https://github.com/jamiefiedler) <[j@jf.dev](mailto:j@jf.dev)> (@jamiefiedler)
 
 
-### Editorial Assignment 
+### Editorial Assignment
 Candidate Proposals to the Solid Specification produced by this panel are likely to be associated with the [Data Interoperability and Portability editorial topic](https://github.com/solid/process/blob/master/editors.md#data-interoperability-and-portability), and will be principally reviewed by any editors assigned to it.
-
-


### PR DESCRIPTION
When panels were first introduced there was a wild proliferation of panels. This resulted in some trouble keeping track of what was going on as mentioned in https://github.com/solid/process/issues/135 

In the process it states that "Panel repositories that are inactive for more than six months may be archived by Solid Administrators." 

With this pull request, the inactive panels have been removed. This does NOT mean that the topics are unimportant or that they should not be picked up at a later stage. It