### PR TITLE
Update to correspond only to Active Panels

### DIFF
--- a/editors.md
+++ b/editors.md
@@ -23,28 +23,9 @@ The Solid Specification covers a broad range of topics, from resource access and
 
 Editorial assignments to the specification are by topic. A given editor may be assigned to one or more topics. Some topics may have dedicated primary documents, while other topics may occur throughout the specification.
 
--   [Resource Access](#resource-access)
--   [Identity](#identity)
 -   [Authentication](#authentication)
 -   [Authorization](#authorization)
--   [Events and Notifications](#events-and-notifications)
--   [Data Interoperability](#data-interoperability)
--   [Data Portability](#data-portability)
--   [Auditing](#auditing)
--   [Querying](#querying)
--   [Cryptography](#cryptography)
--   [Security](#security)
-
-#### Resource Access
-Pertaining to the access of resources in a data pod over a network via HTTP
-
-__Assigned Editors:__ Sarven Capadisli, Kjetil Kjernsmo, Ruben Verborgh   
-__Primary Documents:__  [solid/specification/resource-access](https://github.com/solid/specification/blob/master/main/resource-access.bs)
-
-#### Identity
-Pertaining to mechanisms that universally identify people or applications.  
-__Assigned Editors:__  *No editors assigned yet*   
-__Primary Documents:__
+-   [Interoperability](#interoperability)
 
 #### Authentication
 Pertaining to mechanisms that authenticate a person or application for the purposes of accessing resources in a data pod.  
@@ -56,42 +37,7 @@ Pertaining to mechanisms that control the access a given agent has to read or ma
 __Assigned Editors:__  Kjetil Kjernsmo  
 __Primary Documents:__ [solid/specification/resource-access](https://github.com/solid/specification/blob/master/main/resource-access.bs), [solid/specification/wac](https://github.com/solid/specification/tree/master/wac), [solid/web-access-control-spec](https://github.com/solid/web-access-control-spec)
 
-#### Events and Notifications
-Pertaining to mechanisms that process and/or emit events between pods and agents, or other pods.  
-__Assigned Editors:__  Sarven Capadisli, Ruben Verborgh   
-__Primary Documents:__ 
-
-#### Data Interoperability
+#### Interoperability
 Pertaining to mechanisms that ensure disparate applications or agents can safely and seamlessly read and write the data they need.  
 __Assigned Editors:__ Kjetil Kjernsmo, Ruben Verborgh, Justin Bingham, Sarven Capadisli   
 __Primary Documents:__
-
-#### Data Portability
-Pertaining to mechanisms that ensure the portability of data stored in a data pod such that it can be safely migrated between conformant Solid server implementations, as well as exported to other mediums.  
-__Assigned Editors:__  Justin Bingham   
-__Primary Documents:__
-
-#### Data Models
-Pertaining to core vocabularies and data shapes essential to a working ecosystem of data pods and applications.  
-__Assigned Editors:__  Kjetil Kjernsmo, Justin Bingham, Sarven Capadisli   
-__Primary Documents:__ [solid/vocab](https://github.com/solid/vocab)
-
-#### Auditing
-Pertaining to the mechanisms through which access and manipulation events of resources in a data pod are recorded and accessible.  
-__Assigned Editors:__  *No editors assigned yet*   
-__Primary Documents:__
-
-#### Querying
-Pertaining to the mechanisms, such as SPARQL and TPF, through which a given agent can provide query parameters to a data pod and receive results satisfying the same.  
-__Assigned Editors:__ Kjetil Kjernsmo, Ruben Verborgh   
-__Primary Documents:__
-
-#### Cryptography
-Pertaining to the mechanisms through which cryptographic techniques are employed to provide data privacy, data integrity, and verifiable information.  
-__Assigned Editors:__ *No editors assigned yet*    
-__Primary Documents:__
-
-#### Security
-Pertaining to mechanisms used and considerations taken when securing a data pod, a conformant server implementation, and/or the immediate ecosystem around them.  
-__Assigned Editors:__ Justin Bingham    
-__Primary Documents:__ [solid/specification/security](https://github.com/solid/specification/blob/master/main/security.bs)


### PR DESCRIPTION
Many panels have been inactive for at least 6 months and have therefore been archived according to the process "Panel repositories that are inactive for more than six months may be archived by Solid Administrators." 

This pull request removes the editorial assignments that do not have active panels at the moment. Of course, as soon as there is more activity it would be a good idea to reopen the editorial assignments so that it is clear which editors should review proposals from these panels.