### PR TITLE
Remove Stakeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,6 @@ Panels may request to have a repository created within the [Solid Github Organiz
 
 Panels may request to have a gitter channel created within the [Solid Gitter Organization](https://gitter.im/solid). These requests should be made by submitting an issue to [solid/process](https://github.com/solid/process).
 
-## Stakeholders
-
-Stakeholders are those affected by normative changes to the [Solid Specification](https://github.com/solid/specification). There are two types of Stakeholders; [Solid Users](#solid-users) and [Solid Implementers](#solid-implementers). It is important to consider them both when proposing changes, and adhering to the W3C [priority of constituencies](https://www.w3.org/TR/html-design-principles/#priority-of-constituencies) is encouraged. A Stakeholder may be both a user and an implementer.
-
-Stakeholders who have opted to identify themselves publicly are listed at [stakeholders.md](stakeholders.md). Anyone may decide to identify themselves publicly as a Solid Stakeholder, but it is not mandatory. Identified stakeholders may be consulted for feedback as part of the editorial process.
-
-### Solid Users
-
-Solid Users are individuals, companies, or organizations who access data stored in a Solid Pod.
-
-### Implementers
-Solid Implementers are companies or organizations who are implementing the [Solid Specification](https://github.com/solid/specification). A Solid Implementer may be any combination of Identity Provider, Pod Provider, and Application Provider.
-
 ## How to Make Changes
 
 This section details how changes to the [Solid Specification](https://github.com/solid/specification) may be drafted, proposed, and accepted.


### PR DESCRIPTION
This list is now available on 

https://solidproject.org/use-solid/ for Pod and WebID providers 

and 

https://solidproject.org/use-solid/apps for Solid Apps. 

I propose to delete this list to avoid wiki rot.