### PR TITLE
Fix link in README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Repositories requiring editorial review are listed in [editors.md](editors.md#ed
 Editors have [_Admin Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) on the repositories they are assigned to, and are permitted to grant [_Write Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) to other contributing authors on the same. All members of the Editorial Team have [_Write Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) on all repositories requiring editorial review listed in [editors.md](editors.md).
 
 # Test Suite 
-Test Suite Developers work with the aim is to develop a [test suite]((https://github.com/solid/test-suite) that can be used to verify an implementation against the Solid specification. 
+Test Suite Developers work with the aim is to develop a [test suite](https://github.com/solid/test-suite) that can be used to verify an implementation against the Solid specification. 
 
 # Administration
 


### PR DESCRIPTION
The markdown for the link to the test-suite in the README does not work, as it contains a surplus `(`.

This MR fixes the link by removing the extraneous bracket. 