### PR TITLE
Add system operators for solidcommunity.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,16 @@ Minor changes (such as spelling, grammar, and broken links) do not require revie
 Larger chunks of texts should be reviewed by a Creator or Editor for technical correctness.
 Changes to the main messaging require an approving review by the Director.
 
+# Solidcommunity.net
+
+[Solidcommunity.net](https://solidcommunity.net) is a free pod hosting service
+maintained by the Solid Project for research, development, and experimental,
+non-commercial use of Solid by community members.
+
+It is administered by [System Operators](system-operators.md), with additional 
+support from Solid Project [Administrators](administrators). System Operators 
+are appointed by the Solid Director.
+
 # References
 
 Solid culture documentation was put together with inspiration and learnings from the following resources.

--- a/system-operators.md
+++ b/system-operators.md
@@ -1,0 +1,12 @@
+# System Operators
+
+Below is a listing of System Operators, who provide administrative support
+and operational management of [solidcommunity.net](https://solidcommunity.net).
+
+## System Operators
+
+| Name      | WebID      |
+| --------- | ---------- |
+| [Alain Bourgeois](https://github.com/bourgeoa) | [WebID](https://bourgeoa.solid.community/profile/card#me) |
+| [Eric Prud'hommeaux](https://github.com/ericp) | [WebID](https://ericp.solidcommunity.net) |
+| [Michiel de Jong](https://github.com/michielbdejong) | [WebID](https://michielbdejong.solidcommunity.net/profile/card#me) |


### PR DESCRIPTION
Adding a role for system operators of solidcommunity.net, who provide administrative support to those with pods hosted therein. Also includes appointments of @ericprud, @bourgeoa, and @michielbdejong to the role.