### PR TITLE
Adding Solid World Coordinator role

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Administrators are granted privileged access to control the tools, systems, and 
 
 Administrators belong to the [Administrators Team](https://github.com/orgs/solid/teams/administrators) in the [Solid GitHub Organization](https://github.com/solid) and have [_Admin Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) on all repositories therein. Administrators have [_Owner Permissions_](https://help.github.com/en/articles/permission-levels-for-an-organization#permission-levels-for-an-organization) for the [Solid GitHub Organization](https://github.com/solid).
 
-The Solid World Coordination Administrator is granted privileged access to only those tools, systems, and services required to coordinate and promote the monthly Solid World webinar, such as Vimeo, Twitter, Eventbrite, and/or Typeform.
+The Solid World Coordination Administrator is granted privileged access to such tools, systems, and services as are required to coordinate and promote the monthly Solid World webinar, such as Vimeo, Twitter, Eventbrite, Typeform, and/or others.
 
 ### Becoming an Administrator
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Administrators are granted privileged access to control the tools, systems, and 
 
 Administrators belong to the [Administrators Team](https://github.com/orgs/solid/teams/administrators) in the [Solid GitHub Organization](https://github.com/solid) and have [_Admin Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) on all repositories therein. Administrators have [_Owner Permissions_](https://help.github.com/en/articles/permission-levels-for-an-organization#permission-levels-for-an-organization) for the [Solid GitHub Organization](https://github.com/solid).
 
-The Solid World Coordination Administrator is granted privileged access to only those tools, systems, and services required to coordinate and promote the monthly Solid World webinar, including Vimeo, Twitter, Eventbrite and Typeform.
+The Solid World Coordination Administrator is granted privileged access to only those tools, systems, and services required to coordinate and promote the monthly Solid World webinar, such as Vimeo, Twitter, Eventbrite, and/or Typeform.
 
 ### Becoming an Administrator
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Administrators are granted privileged access to control the tools, systems, and 
 
 Administrators belong to the [Administrators Team](https://github.com/orgs/solid/teams/administrators) in the [Solid GitHub Organization](https://github.com/solid) and have [_Admin Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) on all repositories therein. Administrators have [_Owner Permissions_](https://help.github.com/en/articles/permission-levels-for-an-organization#permission-levels-for-an-organization) for the [Solid GitHub Organization](https://github.com/solid).
 
+The Solid World Coordination Administrator is granted privileged access to only those tools, systems, and services required to coordinate and promote the monthly Solid World webinar, including Vimeo, Twitter, Eventbrite and Typeform.
+
 ### Becoming an Administrator
 
 Administrators are appointed by the Solid Director. Administrators are listed at [administrators.md](administrators.md) along with their contact details and affiliations. Anyone may apply to be an Administrator. Administrator applications are reviewed only by the Solid Director.


### PR DESCRIPTION
At the last Solid Team meeting, we agreed that we need to formally acknowledge the work being done to coordinate Solid World, but that such work should not require a full Solid Administrator position. This PR describes a new roles with more limited admin prvileges.