### PR TITLE
Pause Ruben Verborgh's involvement as an Editor

### DIFF
--- a/editors.md
+++ b/editors.md
@@ -11,7 +11,6 @@ Below is a listing of the Solid Editorial Team and their respective assignments.
 | [Dmitri Zagidulin](https://github.com/dmitrizagidulin) | [WebID](https://dz.solid.community/profile/card#me) |
 | [Kjetil Kjernsmo](https://github.com/kjetilk) | [WebID](https://solid.kjernsmo.net/profile/card#me) |
 | [Sarven Capadisli](https://github.com/csarven) | [WebID](https://csarven.ca/#i) |
-| [Ruben Verborgh](https://github.com/RubenVerborgh) | [WebID](https://ruben.verborgh.org/profile/#me) |
 
 ## Editorial Assignments
 
@@ -38,7 +37,7 @@ Editorial assignments to the specification are by topic. A given editor may be a
 #### Resource Access
 Pertaining to the access of resources in a data pod over a network via HTTP
 
-__Assigned Editors:__ Sarven Capadisli, Kjetil Kjernsmo, Ruben Verborgh   
+__Assigned Editors:__ Sarven Capadisli, Kjetil Kjernsmo  
 __Primary Documents:__  [solid/specification/resource-access](https://github.com/solid/specification/blob/master/main/resource-access.bs)
 
 #### Identity
@@ -59,12 +58,12 @@ __Primary Documents:__ [solid/specification/resource-access](https://github.com/
 
 #### Events and Notifications
 Pertaining to mechanisms that process and/or emit events between pods and agents, or other pods.  
-__Assigned Editors:__  Sarven Capadisli, Ruben Verborgh, Dmitri Zagidulin
+__Assigned Editors:__  Sarven Capadisli, Dmitri Zagidulin
 __Primary Documents:__
 
 #### Data Interoperability
 Pertaining to mechanisms that ensure disparate applications or agents can safely and seamlessly read and write the data they need.  
-__Assigned Editors:__ Kjetil Kjernsmo, Ruben Verborgh, Justin Bingham, Sarven Capadisli   
+__Assigned Editors:__ Kjetil Kjernsmo, Justin Bingham, Sarven Capadisli   
 __Primary Documents:__
 
 #### Data Portability
@@ -84,7 +83,7 @@ __Primary Documents:__
 
 #### Querying
 Pertaining to the mechanisms, such as SPARQL and TPF, through which a given agent can provide query parameters to a data pod and receive results satisfying the same.  
-__Assigned Editors:__ Kjetil Kjernsmo, Ruben Verborgh   
+__Assigned Editors:__ Kjetil Kjernsmo
 __Primary Documents:__
 
 #### Cryptography


### PR DESCRIPTION
I'd like to pause my involvement as an Editor.
I feel lucky to have worked on the specs with a great team, and the groundwork is there now.
0.9 was a great milestone for us all.

Lately, I've noticed that my text contributions have become less due to other Solid commitments, so I feel it would no longer be fair to be listed next to people who are writing significantly more text than I am.

You can still count on my availability for reviewing texts etc., and perhaps I will apply again in the future if my work brings me back to specification texts. In any case, my involvement with Solid will remain at least 100% 😎