### PR TITLE
Add W3C Solid CG Charter

### DIFF
--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -147,7 +147,7 @@ For most Chair nominees, the primary affiliation is their employer and will matc
 * At any given time there may be up to three co-chairs, each holding one seat. Each seat defines a 2 year cycle of service.
 * In the first election after ratification of this charter, all seats will be up for election. Thereafter, in each year, a single election will be held to fill any vacant seats.
 * In the case of interim vacancy, the remaining chairs may appoint a co-chair for each open seat, hold an election for the same, or wait until the next election, at their discretion. If the chairs do not take any action, the seat will automatically be up for election in any cycle. Any such interim appointments or elections shall hold the seat until the end of its natural cycle.
-* There may be up to three Chairs at any given time. Reelection is restricted to two consecutive terms, with the possibility of being reelected after sitting out one election cycle.
+* Reelection is restricted to two consecutive terms, with the possibility of being reelected after sitting out one election cycle.
 * In an election year, current chairs will select a date for elections, which will set a nomination period of two weeks, starting 4 weeks prior to the election.
 * For an individual to run for election, they must self-nominate and make a statement regarding their background and why they are running, on the group mailing list.
 * The current chairs will host a conference call during the nomination period, during which candidates may make a statement and answer questions from the community.

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -25,7 +25,7 @@ In general, topics that are “in scope” include anything related to enabling 
 * Data models that can be used in storages, e.g., policies, data privacy and rights, provenance records and auditing, error messages.
 * Profile descriptions for social and software agents.
 * Registering and finding data.
-* Data shapes.
+* Vocabularies and data shapes.
 * Access requests and grants.
 * Signing messages.
 * Federation.

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -28,7 +28,7 @@ In general, topics that are “in scope” include anything related to enabling 
 * Vocabularies and data shapes.
 * Access requests and grants.
 * Signing messages.
-* Federation.
+* Federation, e.g., message passing, trust, data cascading.
 * Evaluation tools (software programs or online services) that help determine implementation conformance.
 * Publishing test reports and communicating the level of adoption of technical reports.
 

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -1,0 +1,170 @@
+# W3C Solid Community Group Charter
+
+The aims of the [Solid project](https://solidproject.org/) are in line with those of the Web itself: empowerment towards "an equitable, informed and interconnected society" [[ethical-web-principles](https://www.w3.org/TR/ethical-web-principles/)]. Solid adds to existing Web standards to realise a space where individuals and communities can maintain their autonomy, control their data and privacy, and choose applications and services to fulfill their needs.
+
+The mission of the [Solid Community Group](https://www.w3.org/groups/cg/solid/) is to explore and describe the interoperability between different classes of products by using Web communication protocols, global identifiers, authentication and authorization mechanisms, data formats and shapes, notifications, and query interfaces.
+
+The group will aim to give authors of technical reports and software implementers confidence that they can rely on the Solid ecosystem to deliver on the promise of interoperability based on open standards.
+
+The task of the group includes drafting and incubating proposed technical specifications for further standardization and prototyping and testing implementations.
+
+
+## Scope
+
+In general, topics that are “in scope” include anything related to enabling affordances for decentralised Web applications to create and use data across decentralised storages in a way that is secure and privacy respecting for individuals and communities. Work items are intended to be compatible with or extend the [Architecture of the World Wide Web](https://www.w3.org/TR/webarch/). These topics include, but not limited to, the following:
+
+* Protocols for the storage, transmission and portability of data.
+* Authentication and authorization mechanisms.
+* Notifications.
+* Query interfaces.
+* Data models that can be used in storages, e.g., policies, data privacy and rights, provenance records and auditing, error messages.
+* Profile descriptions for social and software agents.
+* Registering and finding data.
+* Data shapes.
+* Access requests and grants.
+* Signing messages.
+* Federation.
+* Evaluation tools (software programs or online services) that help determine implementation conformance.
+* Vocabularies for technical reports, test suite design, tests, and test reports.
+* Publishing test reports and communicating the level of adoption of technical reports.
+
+With the exception of integrating or bridging specifications developed by another active community in an open standards development body that specialises in a particular topic, the Solid Community Group defer the work to the other community.
+
+
+### Out of Scope
+
+In general, topics that are “out of scope” involve anything not directly related to the above. Some examples of these are listed here:
+
+* The relative merits of various economic, political, or sociological theories.
+* Marketing or evangelizing of technologies not intended to be released under a license compatible with W3C specifications. Discussion of out-of-scope solutions should be limited to elaborating upon technological advantages/disadvantages.
+
+
+## Work Items
+
+The Community Group current work items are listed at [Solid Technical Reports](https://solidproject.org/TR/).
+
+In general, all documents in scope of the group are welcome. If there are individuals who will commit to being editors for a document, the group should agree to accept it as a work item even if it conflicts with previous work adopted by the community. Newly-accepted work items that extend beyond the scope of this Community Group Charter will lead to a reconsideration of the Charter. The Community Group may vote to revise the Charter in order to include new work, or to determine that the proposed work is unrelated.
+
+### New Work Item Proposal
+
+* Propose topic to the group in a meeting.
+* Include publicly access link to abstract or draft.
+* List and link to owners (at least 1 person for advancing the work item and 1 other person).
+* Answer the following questions in order to document how you are meeting the requirements for a new work item at the W3C Solid Community Group. Please note if this work item supports certain programs or another government or private sector project.
+  1. Explain what you are trying to do using no jargon or acronyms.
+  2. How is it done today, and what are the limits of the current practice?
+  3. What is new in your approach and why do you think it will be successful?
+  4. How are you involving participants from multiple skill sets and global locations in this work item? (Skill sets: technical, design, product, marketing, anthropological, and UX. Global locations: Africa, the Americas, APAC, Europe, Middle East.)
+  5. What actions are you taking to make this work item accessible to a non-technical audience?
+
+
+## Coordination
+
+The group will make good faith efforts to include the following communities in the progress of our work.
+
+* [Credentials Community Group](https://www.w3.org/groups/cg/credentials)
+* [Data Protection Vocabularies and Controls Community Group](https://www.w3.org/groups/cg/dpvcg)
+* [Decentralized Identifier Working Group](https://www.w3.org/groups/wg/did)
+* [LDP Next Community Group](https://www.w3.org/groups/cg/ldpnext)
+* [Notation 3 (N3) Community Group](https://www.w3.org/groups/cg/n3-dev)
+* [ODRL Community Group](https://www.w3.org/groups/cg/odrl)
+* [RDF-DEV Community Group](https://www.w3.org/groups/cg/rdf-dev)
+* [RDF-star Working Group](https://www.w3.org/groups/wg/rdf-star)
+* [Social Web Incubator Community Group](https://www.w3.org/groups/cg/socialcg)
+* [Verifiable Credentials Working Group](https://www.w3.org/groups/wg/vc)
+* [WebID Community Group](https://www.w3.org/groups/cg/webid)
+* [Web Platform Incubator Community Group](https://www.w3.org/groups/cg/wicg)
+* [Web of Things Working Group](https://www.w3.org/groups/wg/wot)
+
+The group expects to follow the following W3C Recommendations, Guidelines, and Notes, and, if necessary, to liaise with the communities behind them:
+
+* [Architecture of the World Wide Web, Volume I](https://www.w3.org/TR/webarch/)
+* [Internationalization Technical Reports and Notes](http://www.w3.org/International/publications)
+* [QA Framework: Specification Guidelines](http://www.w3.org/TR/qaframe-spec/)
+
+
+## Participation
+
+The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in [Communication](#Communication)
+
+The [Solid Technical Reports Contributing Guide](https://github.com/solid/specification/blob/main/CONTRIBUTING.md) is available to all members of the group that would like to make substantive contributions.
+
+
+## Communication
+
+Technical discussions for this Community Group are conducted in public: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Drafts of specifications will be developed in public repositories and may permit direct public contribution requests. The meetings themselves are open to public participation.
+
+Most Solid Community Group teleconferences will focus on discussion of particular specifications and QA work, and will be conducted on an as-needed basis.
+
+This group primarily conducts its technical work through:
+* GitHub repositories, e.g., https://github.com/solid/specification
+* Teleconference: https://meet.jit.si/solid-cg
+* Ad-hoc discussions and coordination: https://matrix.to/#/#solid_specification:gitter.im
+
+The public mailing list public-solid@w3.org may be used for general discussions and announcements.
+
+
+## Decision Policy
+
+To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional. A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from five to ten working days, depending on the chair's evaluation of the group consensus on the issue. If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Community Group.
+
+All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs.
+
+This charter is written in accordance with the [W3C Process Document (Section 5.2.3, Deciding by Vote)](https://www.w3.org/Consortium/Process/#Votes) and includes no voting procedures beyond what the Process Document requires.
+
+
+## License
+
+The group will use the MIT license for all its work items.
+
+
+## Community Group Process
+
+Anything in this charter that conflicts with requirements of the [Community and Business Group Process](http://www.w3.org/community/about/agreements/) is void.
+
+Unless otherwise stated, the Community Group will follow or aim to be compatible with the [W3C Process](https://www.w3.org/Consortium/Process/).
+
+### Membership and Voting Rights
+
+A general member of the Community Group can be an individual or a member on behalf of an organization. Consistent with W3C rules, in order to formally join the Community Group, a member must have a W3C account and push the “Join” button for the Community Group. However, W3C membership is not required to have a W3C account nor to join the Community Group.
+
+Any member of the Community Group who has also accepted the [W3C Community Contributor License Agreement](https://www.w3.org/community/about/process/cla/) (CLA) as part of the enrollment process is eligible to vote on elections, charter amendments, and other community matters so long as they have completed enrollment by the date that the chairs announce those events to the public mailing list.
+
+The Chairs will determine the list of eligible voting members as of the record date. The Chairs will make the list available to the Community Group two weeks before every election that requires voting members to be carefully identified, and the list will be verified by a third party such as a member of W3C staff or a neutral community member for which there are no strong objections. If the voting list is not ready, then the election date will be moved until two weeks after it is ready.  If the third party has reasonable objections, the election will be delayed until two weeks after such objections are resolved.
+
+### Chairs
+
+The [role of the Chair](https://www.w3.org/Guide/chair/role.html) is described in the [Art of Consensus](https://www.w3.org/Guide/).
+
+The Community Group members appoints (and re-appoints) Chairs for the group.
+
+The chair and the W3C Team Contact of the group SHOULD NOT be the same individual.
+
+Participation as Chair afforded to the specific individuals elected or appointed to those positions, and a participant’s seat MUST NOT be delegated to any other person.
+
+For most Chair nominees, the primary affiliation is their employer and will match their affiliation in the W3C database. For contractors and independents, this will normally be their contracting company or their independent status; in some cases (e.g. where a consultant is consulting for only one organization) this may be the organization for whom the nominee is consulting.
+
+#### Choosing a Chair
+
+* At any given time there may be up to three co-chairs, each holding one seat. Each seat defines a 2 year cycle of service.
+* In the first election after ratification of this charter, all seats will be up for election. Thereafter, in each year, a single election will be held to fill any vacant seats.
+* In the case of interim vacancy, the remaining chairs may appoint a co-chair for each open seat, hold an election for the same, or wait until the next election, at their discretion. If the chairs do not take any action, the seat will automatically be up for election in any cycle. Any such interim appointments or elections shall hold the seat until the end of its natural cycle.
+* There may be up to three Chairs at any given time. Reelection is restricted to two consecutive terms, with the possibility of being reelected after sitting out one election cycle.
+* In an election year, current chairs will select a date for elections, which will set a nomination period of two weeks, starting 4 weeks prior to the election.
+* For an individual to run for election, they must self-nominate and make a statement regarding their background and why they are running, on the group mailing list.
+* The current chairs will host a conference call during the nomination period, during which candidates may make a statement and answer questions from the community.
+* If, at the end of nominations, any given seat only has a single candidate, that candidate immediately wins that seat. For any seats with multiple nominees, there will be an election for those seats.
+* If, after nominations, any given seat has no candidates, the remaining chairs after any election (if necessary for other seats), will address the vacancy as an interim vacancy, described above.
+* To elect one of multiple candidates, a vote will be held by the election mechanism of ranked choice voting, in which voters rank candidates by preference on their ballots. The candidate with the majority (more than 50%) of first-choice votes wins outright. If no candidate gets a majority of first-choice votes, the candidate who ranked the worst is eliminated, and that candidate’s voters’ ballots are redistributed to their second-choice pick. If the vote results in a tie, an immediate runoff of the top two candidates shall be held. If the vote remains tied, the winner shall be the candidate whose nomination was first recorded publicly on the group email list.
+
+#### Removing a Chair
+
+* Chairs may be removed from their duties through a no-confidence vote.
+* If a member of the community group wishes to call for the recall of a chair–for any reason–that member must first privately communicate with the other chairs their desire and reason for doing so. Those chairs must give the member an opportunity to discuss their concerns with a goal of resolving them. If, after 30 days, the member feels their issues are not addressed, they may then escalate to a public call for a no confidence vote. If after 60 days, the member has not made that call for a no confidence vote, the matter is dropped; any further attempts to remove the chair in question must begin with a new round of private communication.
+* A public call for no confidence must be announced to the group email list stating the name of the chair subject to the recall and the names and emails of at least 3 members of the group who thereby call for a recall. This announcement must come from the member who initiated the private communication with the chairs to discuss their concerns. The other two supporting members MUST reply to that email on the public list within 48 hours to confirm their support for a no-confidence vote of the chair in question.
+* The other chairs must acknowledge the call for no confidence within 7 days of all three members declaring their support.
+* Within 30 days of a call for no confidence, the other chairs must hold a conference call at which the parties seeking no confidence will have an opportunity to present their case and members of the group will be able to ask clarifying questions. The chair in question shall not moderate this call. They will, however, have equal time to respond during that same call to the case made against them.
+* During the week following this conference call, members may cast votes in favor or against the recall by posting to the email list. If affirmative votes cast that week (in favor of recall) comprise greater than two-thirds of the total votes cast, then the chair in question is removed and the seat shall be treated as an interim vacancy.
+* Members are not required to vote. Abstentions may be recorded; such abstentions shall not count towards the total number of votes when calculating the two-thirds majority.
+* A Chair who has been removed may stand for re-election.
+* Only one call for no-confidence, for one chair, may be in process at any given time. Priority shall be given to the first such vote to be publicly called. Any subsequent public calls must wait until any previous recalls are resolved, then must start with private communication as described above.

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -22,10 +22,12 @@ In general, topics that are “in scope” include anything related to enabling 
 * Authentication and authorization mechanisms.
 * Notifications.
 * Query interfaces.
-* Data models that can be used in storages, e.g., policies, data privacy and rights, provenance records and auditing, error messages.
+* (Meta)data models that can be used in storages, e.g., policies, data privacy and rights, provenance records and auditing, error messages.
 * Profile descriptions for social and software agents.
-* Registering and finding data.
-* Vocabularies and data shapes.
+* Data interoperability: sharing semantics of the content of resources, e.g., data shapes, data portability. 
+* Service interoperability: sharing semantics on the discovery of actions and access to resources, e.g, web service descriptions, provisioning, portability.
+* User interface affordances: the display of data and services in a view.
+* Vocabularies providing the necessary semantics for the mechanisms defined within the scope of this group.
 * Signing messages.
 * Federation, e.g., message passing, trust, data cascading.
 * Evaluation tools (software programs or online services) that help determine implementation conformance.

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -173,3 +173,13 @@ For most Chair nominees, the primary affiliation is their employer and will matc
 * Members are not required to vote. Abstentions may be recorded; such abstentions shall not count towards the total number of votes when calculating the two-thirds majority.
 * A Chair who has been removed may stand for re-election.
 * Only one call for no-confidence, for one chair, may be in process at any given time. Priority shall be given to the first such vote to be publicly called. Any subsequent public calls must wait until any previous recalls are resolved, then must start with private communication as described above.
+
+## Amendments to this Charter
+
+* Chairs may propose amendments to the charter by asking for a call for principled objections to the new charter. If, after a period of two weeks, no principled objections have been presented by a current member of the group, the new charter is approved.
+* If a principled objection is posted to the mailing list or expressed in a regular call, then the chairs may either drop the amendment or proceed with a public vote.
+* A public vote for a new charter must be called by the chairs within two weeks of the principled objection.
+* Such a vote will be open for two weeks, with ballots cast via the group’s public mailing list. Each member of the group may cast one ballot, “yea” or “nay”. A new charter must receive “yea” on two-thirds of the votes cast in the ranked choice vote, and the total votes cast must represent 5% or greater of the group membership, to pass.
+* The group will use the amendment process for any substantive changes to the goals, scope, deliverables, decision process or rules for amending the charter.
+* Changes to the Coordination does not constitute an amendment to the charter that requires a rechartering vote.
+

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -10,9 +10,7 @@ The mission of the [Solid Community Group](https://www.w3.org/groups/cg/solid/) 
 
 The group will aim to give authors of technical reports and software implementers confidence that they can rely on the Solid ecosystem to deliver on the promise of interoperability based on open standards. Towards that end, the group will operate with a mutual understanding between contributors to technical reports, test suite software maintainers, and software implementers by following a cooperation process for the advancement of the Solid platform based on the [Solid QA](https://solidproject.org/ED/qa) initiative.
 
-The task of the group includes drafting and incubating proposed technical specifications for further standardization and prototyping and testing implementations.
-
-As per W3C [structures for groups](https://www.w3.org/groups/) and [W3C Process](https://www.w3.org/Consortium/Process/), the Community Group will maintain its focus on incubating technical reports and software implementations within the [Scope](#Scope) of the charter, with the aim to transfer mature works to be further worked on under W3C Recommendation Tracks.
+As per W3C [structures for groups](https://www.w3.org/groups/) and [W3C Process](https://www.w3.org/Consortium/Process/), the Community Group will maintain its focus on [incubating](https://www.w3.org/Guide/incubation) technical reports, prototyping software, and testing implementations within the [Scope](#Scope) of the charter, with the aim to advance mature works to the W3C Recommendation track in a Working Group.
 
 The Solid community with various stakeholders comes together under the umbrella of the [Solid Project](https://solidproject.org/), and thus the W3C Solid Community Group interacts and coordinates with the Project's organisation as a whole to help inform the work with the needs of the wider community. 
 

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -10,6 +10,7 @@ This group expects to follow the [W3C Web Platform Design Principles](https://ww
 
 The task of the group includes drafting and incubating proposed technical specifications for further standardization and prototyping and testing implementations.
 
+As per W3C [structures for groups](https://www.w3.org/groups/) and [W3C Process](https://www.w3.org/Consortium/Process/), the Community Group will maintain its focus on incubating technical reports and software implementations within the [Scope](#Scope) of the charter, with the aim to transfer mature works to be further worked on under W3C Recommendation Tracks.
 
 ## Scope
 
@@ -38,6 +39,7 @@ In general, topics that are “out of scope” involve anything not directly rel
 
 * The relative merits of various economic, political, or sociological theories.
 * Marketing or evangelizing of technologies not intended to be released under a license compatible with W3C specifications. Discussion of out-of-scope solutions should be limited to elaborating upon technological advantages/disadvantages.
+* Community Group's Work Items that have transitioned to a deliverable of an active Working Group.
 
 
 ## Work Items

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -10,7 +10,7 @@ The mission of the [Solid Community Group](https://www.w3.org/groups/cg/solid/) 
 
 The group will aim to give authors of technical reports and software implementers confidence that they can rely on the Solid ecosystem to deliver on the promise of interoperability based on open standards. Towards that end, the group will operate with a mutual understanding between contributors to technical reports, test suite software maintainers, and software implementers by following a cooperation process for the advancement of the Solid platform based on the [Solid QA](https://solidproject.org/ED/qa) initiative.
 
-As per W3C [structures for groups](https://www.w3.org/groups/) and [W3C Process](https://www.w3.org/Consortium/Process/), the Community Group will maintain its focus on [incubating](https://www.w3.org/Guide/incubation) technical reports, prototyping software, and testing implementations within the [Scope](#Scope) of the charter, with the aim to advance mature works to the W3C Recommendation track in a Working Group.
+As per W3C [structures for groups](https://www.w3.org/groups/) and [W3C Process](https://www.w3.org/Consortium/Process/), the Community Group will maintain its focus on [incubating](https://www.w3.org/Guide/incubation) technical reports, prototyping software, and testing implementations within the [Scope](#Scope) of the charter, with the aim of advancing mature works to the W3C Recommendation track in a Working Group.
 
 The Solid community with various stakeholders comes together under the umbrella of the [Solid Project](https://solidproject.org/), and thus the W3C Solid Community Group interacts and coordinates with the Project's organisation as a whole to help inform the work with the needs of the wider community. 
 
@@ -114,7 +114,7 @@ The public mailing list public-solid@w3.org may be used for general discussions 
 
 ## Decision Policy
 
-To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional. A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from five to ten working days, depending on the chair's evaluation of the group consensus on the issue. If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Community Group.
+To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional. A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue, or web-based survey), with a response period of five to ten working days, depending on the chair's evaluation of the group consensus on the issue. If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Community Group.
 
 All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs.
 

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -129,7 +129,6 @@ The group will use [W3C copyright licenses](https://www.w3.org/copyright/) for a
 
 The group strongly encourages its participants, as well as other stakeholders in the Solid ecosystem, to use the [MIT license](https://opensource.org/license/mit/), or another [OSI approved license](https://opensource.org/license/), for any open source software conforming to Solid specifications.
 
-Deviations from the clauses in this section can still be added to this charter, pending the discussion under [issue 327](https://github.com/solid/process/issues/327) of the [solid/process](https://github.com/solid/process) repository on GitHub, until at the latest the day before this charter goes into effect, viz. 2023-08-31. After the last amendment, or at the end of that day, this paragraph will be removed from the charter.
 
 
 ## Community Group Process

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -6,8 +6,6 @@ The mission of the [Solid Community Group](https://www.w3.org/groups/cg/solid/) 
 
 The group will aim to give authors of technical reports and software implementers confidence that they can rely on the Solid ecosystem to deliver on the promise of interoperability based on open standards.
 
-This group expects to follow the [W3C Web Platform Design Principles](https://www.w3.org/TR/design-principles/) when considering and developing features.
-
 The task of the group includes drafting and incubating proposed technical specifications for further standardization and prototyping and testing implementations.
 
 As per W3C [structures for groups](https://www.w3.org/groups/) and [W3C Process](https://www.w3.org/Consortium/Process/), the Community Group will maintain its focus on incubating technical reports and software implementations within the [Scope](#Scope) of the charter, with the aim to transfer mature works to be further worked on under W3C Recommendation Tracks.
@@ -87,6 +85,7 @@ The group expects to follow the following W3C Recommendations, Guidelines, and N
 * [Architecture of the World Wide Web, Volume I](https://www.w3.org/TR/webarch/)
 * [Internationalization Technical Reports and Notes](http://www.w3.org/International/publications)
 * [QA Framework: Specification Guidelines](http://www.w3.org/TR/qaframe-spec/)
+* [W3C Web Platform Design Principles](https://www.w3.org/TR/design-principles/)
 
 
 ## Participation

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -102,7 +102,7 @@ The [Solid Technical Reports Contributing Guide](https://github.com/solid/specif
 
 ## Communication
 
-Technical discussions for this Community Group are conducted in public: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Drafts of specifications will be developed in public repositories and may permit direct public contribution requests. The meetings themselves are open to public participation.
+Technical discussions for this Community Group are conducted in public: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Work items will be developed in public repositories and may permit direct public contribution requests. The meetings themselves are open to public participation.
 
 Most Solid Community Group teleconferences will focus on discussion of particular specifications and QA work, and will be conducted on an as-needed basis.
 

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -26,7 +26,6 @@ In general, topics that are “in scope” include anything related to enabling 
 * Profile descriptions for social and software agents.
 * Registering and finding data.
 * Vocabularies and data shapes.
-* Access requests and grants.
 * Signing messages.
 * Federation, e.g., message passing, trust, data cascading.
 * Evaluation tools (software programs or online services) that help determine implementation conformance.

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -14,7 +14,7 @@ The task of the group includes drafting and incubating proposed technical specif
 
 As per W3C [structures for groups](https://www.w3.org/groups/) and [W3C Process](https://www.w3.org/Consortium/Process/), the Community Group will maintain its focus on incubating technical reports and software implementations within the [Scope](#Scope) of the charter, with the aim to transfer mature works to be further worked on under W3C Recommendation Tracks.
 
-The Solid community with various stakeholders comes together under the umbrella of the Solid Project, and thus the W3C Solid Community Group interacts and coordinates with the Project's organisation as a whole to help inform the work with the needs of the wider community. 
+The Solid community with various stakeholders comes together under the umbrella of the [Solid Project](https://solidproject.org/), and thus the W3C Solid Community Group interacts and coordinates with the Project's organisation as a whole to help inform the work with the needs of the wider community. 
 
 ## Scope
 
@@ -72,6 +72,7 @@ The group will make good faith efforts to include the following communities in t
 * [Autonomous Agents on the Web Community Group](https://www.w3.org/groups/cg/webagents)
 * [Credentials Community Group](https://www.w3.org/groups/cg/credentials)
 * [Data Protection Vocabularies and Controls Community Group](https://www.w3.org/groups/cg/dpvcg)
+* [Dataset Exchange Working Group](https://www.w3.org/groups/wg/dx/)
 * [Decentralized Identifier Working Group](https://www.w3.org/groups/wg/did)
 * [LDP Next Community Group](https://www.w3.org/groups/cg/ldpnext)
 * [Notation 3 (N3) Community Group](https://www.w3.org/groups/cg/n3-dev)
@@ -96,7 +97,7 @@ The group expects to follow the following W3C Recommendations, Guidelines, and N
 
 The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in [Communication](#Communication)
 
-The [Solid Technical Reports Contributing Guide](https://github.com/solid/specification/blob/main/CONTRIBUTING.md) is available to all members of the group that would like to make substantive contributions.
+The [Solid Technical Reports Contributing Guide](https://github.com/solid/specification/blob/main/CONTRIBUTING.md) is available to all participants of the group that would like to make substantive contributions.
 
 
 ## Communication
@@ -133,19 +134,19 @@ Anything in this charter that conflicts with requirements of the [Community and 
 
 Unless otherwise stated, the Community Group will follow or aim to be compatible with the [W3C Process](https://www.w3.org/Consortium/Process/).
 
-### Membership and Voting Rights
+### Participation and Voting Rights
 
-A general member of the Community Group can be an individual or a member on behalf of an organization. Consistent with W3C rules, in order to formally join the Community Group, a member must have a W3C account and push the “Join” button for the Community Group. However, W3C membership is not required to have a W3C account nor to join the Community Group.
+A general participant of the Community Group can be an individual representing themself or an organization. Consistent with W3C rules, in order to formally join the Community Group, a participant must have a W3C account and push the “Join” button for the Community Group. However, W3C membership is not required to have a W3C account nor to join the Community Group.
 
-Any member of the Community Group who has also accepted the [W3C Community Contributor License Agreement](https://www.w3.org/community/about/process/cla/) (CLA) as part of the enrollment process is eligible to vote on elections, charter amendments, and other community matters so long as they have completed enrollment by the date that the chairs announce those events to the public mailing list.
+Any participant of the Community Group who has also accepted the [W3C Community Contributor License Agreement](https://www.w3.org/community/about/process/cla/) (CLA) as part of the enrollment process is eligible to vote on elections, charter amendments, and other community matters so long as they have completed enrollment by the date that the chairs announce those events to the public mailing list.
 
-The Chairs will determine the list of eligible voting members as of the record date. The Chairs will make the list available to the Community Group two weeks before every election that requires voting members to be carefully identified, and the list will be verified by a third party such as a member of W3C staff or a neutral community member for which there are no strong objections. If the voting list is not ready, then the election date will be moved until two weeks after it is ready.  If the third party has reasonable objections, the election will be delayed until two weeks after such objections are resolved.
+The Chairs will determine the list of eligible voting participants as of the record date. The Chairs will make the list available to the Community Group two weeks before every election that requires voting participants to be carefully identified, and the list will be verified by a third party such as a member of W3C staff or a neutral community member for which there are no strong objections. If the voting list is not ready, then the election date will be moved until two weeks after it is ready.  If the third party has reasonable objections, the election will be delayed until two weeks after such objections are resolved.
 
 ### Chairs
 
 The [role of the Chair](https://www.w3.org/Guide/chair/role.html) is described in the [Art of Consensus](https://www.w3.org/Guide/).
 
-The Community Group members appoints (and re-appoints) Chairs for the group.
+The Community Group participants appoints (and re-appoints) Chairs for the group.
 
 The chair and the W3C Team Contact of the group SHOULD NOT be the same individual.
 
@@ -169,21 +170,21 @@ For most Chair nominees, the primary affiliation is their employer and will matc
 #### Removing a Chair
 
 * Chairs may be removed from their duties through a no-confidence vote.
-* If a member of the community group wishes to call for the recall of a chair–for any reason–that member must first privately communicate with the other chairs their desire and reason for doing so. Those chairs must give the member an opportunity to discuss their concerns with a goal of resolving them. If, after 30 days, the member feels their issues are not addressed, they may then escalate to a public call for a no confidence vote. If after 60 days, the member has not made that call for a no confidence vote, the matter is dropped; any further attempts to remove the chair in question must begin with a new round of private communication.
-* A public call for no confidence must be announced to the group email list stating the name of the chair subject to the recall and the names and emails of at least 3 members of the group who thereby call for a recall. This announcement must come from the member who initiated the private communication with the chairs to discuss their concerns. The other two supporting members MUST reply to that email on the public list within 48 hours to confirm their support for a no-confidence vote of the chair in question.
-* The other chairs must acknowledge the call for no confidence within 7 days of all three members declaring their support.
-* Within 30 days of a call for no confidence, the other chairs must hold a conference call at which the parties seeking no confidence will have an opportunity to present their case and members of the group will be able to ask clarifying questions. The chair in question shall not moderate this call. They will, however, have equal time to respond during that same call to the case made against them.
-* During the week following this conference call, members may cast votes in favor or against the recall by posting to the email list. If affirmative votes cast that week (in favor of recall) comprise greater than two-thirds of the total votes cast, then the chair in question is removed and the seat shall be treated as an interim vacancy.
-* Members are not required to vote. Abstentions may be recorded; such abstentions shall not count towards the total number of votes when calculating the two-thirds majority.
+* If a participant of the community group wishes to call for the recall of a chair–for any reason–that participant must first privately communicate with the other chairs their desire and reason for doing so. Those chairs must give the participant an opportunity to discuss their concerns with a goal of resolving them. If, after 30 days, the participant feels their issues are not addressed, they may then escalate to a public call for a no confidence vote. If after 60 days, the participant has not made that call for a no confidence vote, the matter is dropped; any further attempts to remove the chair in question must begin with a new round of private communication.
+* A public call for no confidence must be announced to the group email list stating the name of the chair subject to the recall and the names and emails of at least 3 participants of the group who thereby call for a recall. This announcement must come from the participant who initiated the private communication with the chairs to discuss their concerns. The other two supporting participants MUST reply to that email on the public list within 48 hours to confirm their support for a no-confidence vote of the chair in question.
+* The other chairs must acknowledge the call for no confidence within 7 days of all three participants declaring their support.
+* Within 30 days of a call for no confidence, the other chairs must hold a conference call at which the parties seeking no confidence will have an opportunity to present their case and participants of the group will be able to ask clarifying questions. The chair in question shall not moderate this call. They will, however, have equal time to respond during that same call to the case made against them.
+* During the week following this conference call, participants may cast votes in favor or against the recall by posting to the email list. If affirmative votes cast that week (in favor of recall) comprise greater than two-thirds of the total votes cast, then the chair in question is removed and the seat shall be treated as an interim vacancy.
+* Participants are not required to vote. Abstentions may be recorded; such abstentions shall not count towards the total number of votes when calculating the two-thirds majority.
 * A Chair who has been removed may stand for re-election.
 * Only one call for no-confidence, for one chair, may be in process at any given time. Priority shall be given to the first such vote to be publicly called. Any subsequent public calls must wait until any previous recalls are resolved, then must start with private communication as described above.
 
 ## Amendments to this Charter
 
-* Chairs may propose amendments to the charter by asking for a call for principled objections to the new charter. If, after a period of two weeks, no principled objections have been presented by a current member of the group, the new charter is approved.
+* Chairs may propose amendments to the charter by asking for a call for principled objections to the new charter. If, after a period of two weeks, no principled objections have been presented by a current participant of the group, the new charter is approved.
 * If a principled objection is posted to the mailing list or expressed in a regular call, then the chairs may either drop the amendment or proceed with a public vote.
 * A public vote for a new charter must be called by the chairs within two weeks of the principled objection.
-* Such a vote will be open for two weeks, with ballots cast via the group’s public mailing list. Each member of the group may cast one ballot, “yea” or “nay”. A new charter must receive “yea” on two-thirds of the votes cast in the ranked choice vote, and the total votes cast must represent 5% or greater of the group membership, to pass.
+* Such a vote will be open for two weeks, with ballots cast via the group’s public mailing list. Each participant of the group may cast one ballot, “yea” or “nay”. A new charter must receive “yea” on two-thirds of the votes cast in the ranked choice vote, and the total votes cast must represent 5% or greater of the group participants, to pass.
 * The group will use the amendment process for any substantive changes to the goals, scope, deliverables, decision process or rules for amending the charter.
 * Changes to the Coordination does not constitute an amendment to the charter that requires a rechartering vote.
 

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -141,6 +141,10 @@ Participation as Chair afforded to the specific individuals elected or appointed
 
 For most Chair nominees, the primary affiliation is their employer and will match their affiliation in the W3C database. For contractors and independents, this will normally be their contracting company or their independent status; in some cases (e.g. where a consultant is consulting for only one organization) this may be the organization for whom the nominee is consulting.
 
+Chair nominees and elected chairs per term MUST have unique affiliations.
+
+An affiliation MAY submit one ballot that ranks candidates in their preferred order.
+
 #### Choosing a Chair
 
 * At any given time there may be up to three co-chairs, each holding one seat. Each seat defines a 2 year cycle of service.

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -1,7 +1,7 @@
 # W3C Solid Community Group Charter
 
 * Created: 2023-07-04
-* Modified: 2023-07-10
+* Modified: 2023-08-01
 * Version: 1.0
 
 The aims of the [Solid project](https://solidproject.org/) are in line with those of the Web itself: empowerment towards "an equitable, informed and interconnected society" [[ethical-web-principles](https://www.w3.org/TR/ethical-web-principles/)]. Solid adds to existing Web standards to realise a space where individuals and communities can maintain their autonomy, control their data and privacy, and choose applications and services to fulfill their needs.

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -12,6 +12,8 @@ The task of the group includes drafting and incubating proposed technical specif
 
 As per W3C [structures for groups](https://www.w3.org/groups/) and [W3C Process](https://www.w3.org/Consortium/Process/), the Community Group will maintain its focus on incubating technical reports and software implementations within the [Scope](#Scope) of the charter, with the aim to transfer mature works to be further worked on under W3C Recommendation Tracks.
 
+The Solid community with various stakeholders comes together under the umbrella of the Solid Project, and thus the W3C Solid Community Group interacts and coordinates with the Project's organisation as a whole to help inform the work with the needs of the wider community. 
+
 ## Scope
 
 In general, topics that are “in scope” include anything related to enabling affordances for decentralised Web applications to create and use data across decentralised storages in a way that is secure and privacy respecting for individuals and communities. Work items are intended to be compatible with or extend the [Architecture of the World Wide Web](https://www.w3.org/TR/webarch/). These topics include, but not limited to, the following:

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -1,7 +1,7 @@
 # W3C Solid Community Group Charter
 
 * Created: 2023-07-04
-* Modified: 2023-08-01
+* Modified: 2023-09-06
 * Effective: 2023-09-01
 * Version: 1.0
 

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -129,7 +129,7 @@ The group will use [W3C copyright licenses](https://www.w3.org/copyright/) for a
 
 The group strongly encourages its participants, as well as other stakeholders in the Solid ecosystem, to use the [MIT license](https://opensource.org/license/mit/), or another [OSI approved license](https://opensource.org/license/), for any open source software conforming to Solid specifications.
 
-Derivations from the clauses in this section can still be added to this charter, pending the discussion under [issue 327](https://github.com/solid/process/issues/327) of the [solid/process](https://github.com/solid/process) repository on GitHub, until at the latest the day before this charter goes into effect, viz. 2023-08-31. After the last amendment, or at the end of that day, this paragraph will be removed from the charter.
+Deviations from the clauses in this section can still be added to this charter, pending the discussion under [issue 327](https://github.com/solid/process/issues/327) of the [solid/process](https://github.com/solid/process) repository on GitHub, until at the latest the day before this charter goes into effect, viz. 2023-08-31. After the last amendment, or at the end of that day, this paragraph will be removed from the charter.
 
 
 ## Community Group Process

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -25,7 +25,6 @@ In general, topics that are “in scope” include anything related to enabling 
 * Signing messages.
 * Federation.
 * Evaluation tools (software programs or online services) that help determine implementation conformance.
-* Vocabularies for technical reports, test suite design, tests, and test reports.
 * Publishing test reports and communicating the level of adoption of technical reports.
 
 With the exception of integrating or bridging specifications developed by another active community in an open standards development body that specialises in a particular topic, the Solid Community Group defer the work to the other community.
@@ -62,6 +61,7 @@ In general, all documents in scope of the group are welcome. If there are indivi
 
 The group will make good faith efforts to include the following communities in the progress of our work.
 
+* [Autonomous Agents on the Web Community Group](https://www.w3.org/groups/cg/webagents)
 * [Credentials Community Group](https://www.w3.org/groups/cg/credentials)
 * [Data Protection Vocabularies and Controls Community Group](https://www.w3.org/groups/cg/dpvcg)
 * [Decentralized Identifier Working Group](https://www.w3.org/groups/wg/did)

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -2,6 +2,7 @@
 
 * Created: 2023-07-04
 * Modified: 2023-08-01
+* Effective: 2023-09-01
 * Version: 1.0
 
 The aims of the [Solid project](https://solidproject.org/) are in line with those of the Web itself: empowerment towards "an equitable, informed and interconnected society" [[ethical-web-principles](https://www.w3.org/TR/ethical-web-principles/)]. Solid adds to existing Web standards to realise a space where individuals and communities can maintain their autonomy, control their data and privacy, and choose applications and services to fulfill their needs.

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -50,17 +50,7 @@ The Community Group current work items are listed at [Solid Technical Reports](h
 
 In general, all documents in scope of the group are welcome. If there are individuals who will commit to being editors for a document, the group should agree to accept it as a work item even if it conflicts with previous work adopted by the community. Newly-accepted work items that extend beyond the scope of this Community Group Charter will lead to a reconsideration of the Charter. The Community Group may vote to revise the Charter in order to include new work, or to determine that the proposed work is unrelated.
 
-### New Work Item Proposal
-
-* Propose topic to the group in a meeting.
-* Include publicly access link to abstract or draft.
-* List and link to owners (at least 1 person for advancing the work item and 1 other person).
-* Answer the following questions in order to document how you are meeting the requirements for a new work item at the W3C Solid Community Group. Please note if this work item supports certain programs or another government or private sector project.
-  1. Explain what you are trying to do using no jargon or acronyms.
-  2. How is it done today, and what are the limits of the current practice?
-  3. What is new in your approach and why do you think it will be successful?
-  4. How are you involving participants from multiple skill sets and global locations in this work item? (Skill sets: technical, design, product, marketing, anthropological, and UX. Global locations: Africa, the Americas, APAC, Europe, Middle East.)
-  5. What actions are you taking to make this work item accessible to a non-technical audience?
+[The work item process is outlined here](https://github.com/solid/specification/blob/main/CONTRIBUTING.md#work-items).
 
 
 ## Coordination

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -115,7 +115,21 @@ This charter is written in accordance with the [W3C Process Document (Section 5.
 
 ## License
 
-The group will use the MIT license for all its work items.
+The group will use [W3C copyright licenses](https://www.w3.org/copyright/) for all its work items except any software code artifacts, for which the group will use the [MIT license](https://opensource.org/license/mit/).
+
+- Per W3C Process, all contributions to the group fall under the [W3C Community Contributor License Agreement](https://www.w3.org/community/about/process/cla/) (CLA). 
+
+- When finalizing a W3C Community Group Draft Report towards a W3C Community Group Final Report, e.g., to transition the report to a Working Group, the group will contact all actual contributors to the report to secure their commitment to the [W3C Final Specification Agreement](https://www.w3.org/community/about/process/final/) (FSA). 
+
+  Note that per W3C Process, all Technical Reports a Working Group publishes will fall under the [W3C Document License](https://www.w3.org/copyright/document-license-2023/).
+
+- In accordance with the CLA, the group licenses all its software artifacts under the [MIT license](https://opensource.org/license/mit/). 
+
+  Note that per W3C Process, all software artifacts that become part of a Working Group's Technical Reports will fall under the [W3C Software License](https://www.w3.org/copyright/software-license-2023/), and any W3C Authoritative Test Suite a Working Group publishes will fall under a [dual license](https://www.w3.org/copyright/test-suites-licenses/) combining the [W3C Test Suite License](https://www.w3.org/copyright/test-suite-license-2023/) and the [W3C's 3-clause BSD license](https://www.w3.org/copyright/3-clause-bsd-license-2008/).
+
+The group strongly encourages its participants, as well as other stakeholders in the Solid ecosystem, to use the [MIT license](https://opensource.org/license/mit/), or another [OSI approved license](https://opensource.org/license/), for any open source software conforming to Solid specifications.
+
+Derivations from the clauses in this section can still be added to this charter, pending the discussion under [issue 327](https://github.com/solid/process/issues/327) of the [solid/process](https://github.com/solid/process) repository on GitHub, until at the latest the day before this charter goes into effect, viz. 2023-08-31. After the last amendment, or at the end of that day, this paragraph will be removed from the charter.
 
 
 ## Community Group Process

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -6,6 +6,7 @@ The mission of the [Solid Community Group](https://www.w3.org/groups/cg/solid/) 
 
 The group will aim to give authors of technical reports and software implementers confidence that they can rely on the Solid ecosystem to deliver on the promise of interoperability based on open standards.
 
+ This group expects to follow the [W3C Web Platform Design Principles](https://www.w3.org/TR/design-principles/) when considering and developing features.
 The task of the group includes drafting and incubating proposed technical specifications for further standardization and prototyping and testing implementations.
 
 

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -1,5 +1,9 @@
 # W3C Solid Community Group Charter
 
+* Created: 2023-07-04
+* Modified: 2023-07-10
+* Version: 1.0
+
 The aims of the [Solid project](https://solidproject.org/) are in line with those of the Web itself: empowerment towards "an equitable, informed and interconnected society" [[ethical-web-principles](https://www.w3.org/TR/ethical-web-principles/)]. Solid adds to existing Web standards to realise a space where individuals and communities can maintain their autonomy, control their data and privacy, and choose applications and services to fulfill their needs.
 
 The mission of the [Solid Community Group](https://www.w3.org/groups/cg/solid/) is to explore and describe the interoperability between different classes of products by using Web communication protocols, global identifiers, authentication and authorization mechanisms, data formats and shapes, notifications, and query interfaces.

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -8,7 +8,7 @@ The aims of the [Solid project](https://solidproject.org/) are in line with thos
 
 The mission of the [Solid Community Group](https://www.w3.org/groups/cg/solid/) is to explore and describe the interoperability between different classes of products by using Web communication protocols, global identifiers, authentication and authorization mechanisms, data formats and shapes, notifications, and query interfaces.
 
-The group will aim to give authors of technical reports and software implementers confidence that they can rely on the Solid ecosystem to deliver on the promise of interoperability based on open standards.
+The group will aim to give authors of technical reports and software implementers confidence that they can rely on the Solid ecosystem to deliver on the promise of interoperability based on open standards. Towards that end, the group will operate with a mutual understanding between contributors to technical reports, test suite software maintainers, and software implementers by following a cooperation process for the advancement of the Solid platform based on the [Solid QA](https://solidproject.org/ED/qa) initiative.
 
 The task of the group includes drafting and incubating proposed technical specifications for further standardization and prototyping and testing implementations.
 

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -6,7 +6,8 @@ The mission of the [Solid Community Group](https://www.w3.org/groups/cg/solid/) 
 
 The group will aim to give authors of technical reports and software implementers confidence that they can rely on the Solid ecosystem to deliver on the promise of interoperability based on open standards.
 
- This group expects to follow the [W3C Web Platform Design Principles](https://www.w3.org/TR/design-principles/) when considering and developing features.
+This group expects to follow the [W3C Web Platform Design Principles](https://www.w3.org/TR/design-principles/) when considering and developing features.
+
 The task of the group includes drafting and incubating proposed technical specifications for further standardization and prototyping and testing implementations.
 
 

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -121,11 +121,11 @@ The group will use [W3C copyright licenses](https://www.w3.org/copyright/) for a
 
 - When finalizing a W3C Community Group Draft Report towards a W3C Community Group Final Report, e.g., to transition the report to a Working Group, the group will contact all actual contributors to the report to secure their commitment to the [W3C Final Specification Agreement](https://www.w3.org/community/about/process/final/) (FSA). 
 
-  Note that per W3C Process, all Technical Reports a Working Group publishes will fall under the [W3C Document License](https://www.w3.org/copyright/document-license-2023/).
+  Note that the intention of this group is to propose its documents as Technical Reports to a Working Group, where the published documents will fall under the [W3C Document License](https://www.w3.org/copyright/document-license-2023/).
 
-- In accordance with the CLA, the group licenses all its software artifacts under the [MIT license](https://opensource.org/license/mit/). 
+- In accordance with the CLA, the group licenses all its software artifacts under the [W3C Software license](https://www.w3.org/copyright/software-license-2023/), but without the notification obligation. 
 
-  Note that per W3C Process, all software artifacts that become part of a Working Group's Technical Reports will fall under the [W3C Software License](https://www.w3.org/copyright/software-license-2023/), and any W3C Authoritative Test Suite a Working Group publishes will fall under a [dual license](https://www.w3.org/copyright/test-suites-licenses/) combining the [W3C Test Suite License](https://www.w3.org/copyright/test-suite-license-2023/) and the [W3C's 3-clause BSD license](https://www.w3.org/copyright/3-clause-bsd-license-2008/).
+  Note that the intention of this group is to propose its software artifacts and code snippets included in documents to be part of a Working Group's Technical Reports, where they will fall under the [W3C Software License](https://www.w3.org/copyright/software-license-2023/), but without notification obligation; any W3C Authoritative Test Suite a Working Group publishes will fall under a [dual license](https://www.w3.org/copyright/test-suites-licenses/) combining the [W3C Test Suite License](https://www.w3.org/copyright/test-suite-license-2023/) and the [W3C's 3-clause BSD license](https://www.w3.org/copyright/3-clause-bsd-license-2008/).
 
 The group strongly encourages its participants, as well as other stakeholders in the Solid ecosystem, to use the [MIT license](https://opensource.org/license/mit/), or another [OSI approved license](https://opensource.org/license/), for any open source software conforming to Solid specifications.
 


### PR DESCRIPTION
(W3C Solid CG Chair hat on)

I believe it would serve the W3C Solid CG well to have a charter and with a revised simple and clear process.

In this PR, I would like us, the CG members, to consider adopting a charter that can work better going forward. The charter aims to:

* Simplify the process.
* Representative of current working practice.
* Ensure openness and transparency.
* Be approachable as well as informative to newcomers.

It is intended to supersede the process outlined in solid/process (README). The current process in general is:

* Outdated and does not reflect reality.
* Complicated and convoluted.
* Dependent roles (such as the "Editors Team") have been inadequate and inactive for a number of years.

This charter is written in accordance with the W3C Process and aims to remain compatible as much as possible. In addition to following a typical W3C charter outline, the document includes chair elections and work item proposals. Some of this information could be moved to other documents or repositories but it is presented to you as a whole to kick things off. For example, the [Solid Technical Reports Contributing Guide](https://github.com/solid/specification/blob/main/CONTRIBUTING.md) is a thing on its own to have a shared understanding of what's in practice as well as providing detailed information on how individuals can contribute to the CG.

On chairs: the Solid CG would certainly benefit from more chairs representing a wider and more diverse set of voices and perspectives in the community, as well as giving the people who have a demonstrated track record of participation and work in the CG the opportunity to continue their service in a more effective and efficient way, with the proper structures for their work to be meaningful and impactful. For these reasons, when this charter is effective, I intend to arrange an election and open up the option to anyone in the Solid CG. The election process is based on what other CGs have done, and has been working well.

On work items: the Solid CG, within the framework of a W3C CG, generally have a "low bar" to getting stuff done based on open participation and volunteerism. Hence, the process is only intended to help the CG ensure that proposed works are within the scope of the CG, its placement among other work items is understood by group members, and ownership and commitments are stated up front.

This charter is meant to serve as a starting point for the CG to collaborate on the definition and refinement of the processes. Contributions in the form of feedback and requests for clarification (among others) are welcomed and encouraged.

Let's make it so! :)