### PR TITLE
Add document status to CG documents

### DIFF
--- a/notifications-panel-charter.md
+++ b/notifications-panel-charter.md
@@ -1,3 +1,15 @@
+<details open="">
+  <summary>Document Status</summary>
+  <dl>
+    <dt>Modified</dt>
+    <dd>2023-11-14</dd>
+    <dt>Reason</dt>
+    <dd>This document is no longer effective and is no longer being updated here. For the latest information on the <a href="https://www.w3.org/groups/cg/solid/">W3C Solid Community Group</a>, please refer to its <a href="https://github.com/w3c-cg/solid/">repository</a>, <a href="https://www.w3.org/community/solid/charter/">charter</a>, and <a href="https://github.com/w3c-cg/solid/blob/main/CONTRIBUTING.md">contributing guidelines</a>.</dd>
+  </dl>
+</details>
+
+---
+
 # Notifications Panel Charter
 
 The mission of the Notifications Panel as part of the W3C Solid Community Group is to extend or define technical protocols and vocabularies to facilitate notification exchange on the Open Web Platform.

--- a/solid-cg-charter.md
+++ b/solid-cg-charter.md
@@ -1,3 +1,15 @@
+<details open="">
+  <summary>Document Status</summary>
+  <dl>
+    <dt>Modified</dt>
+    <dd>2023-11-14</dd>
+    <dt>Reason</dt>
+    <dd>This document is no longer effective and is no longer being updated here. For the latest information on the <a href="https://www.w3.org/groups/cg/solid/">W3C Solid Community Group</a>, please refer to its <a href="https://github.com/w3c-cg/solid/">repository</a>, <a href="https://www.w3.org/community/solid/charter/">charter</a>, and <a href="https://github.com/w3c-cg/solid/blob/main/CONTRIBUTING.md">contributing guidelines</a>.</dd>
+  </dl>
+</details>
+
+---
+
 # W3C Solid Community Group Charter
 
 * Created: 2023-07-04

--- a/solid-editors-tr-process.md
+++ b/solid-editors-tr-process.md
@@ -1,4 +1,16 @@
-﻿# Solid Editors’ Technical Report Development Process
+﻿<details open="">
+  <summary>Document Status</summary>
+  <dl>
+    <dt>Modified</dt>
+    <dd>2023-11-14</dd>
+    <dt>Reason</dt>
+    <dd>This document is no longer effective and is no longer being updated here. For the latest information on the <a href="https://www.w3.org/groups/cg/solid/">W3C Solid Community Group</a>, please refer to its <a href="https://github.com/w3c-cg/solid/">repository</a>, <a href="https://www.w3.org/community/solid/charter/">charter</a>, and <a href="https://github.com/w3c-cg/solid/blob/main/CONTRIBUTING.md">contributing guidelines</a>.</dd>
+  </dl>
+</details>
+
+---
+
+# Solid Editors’ Technical Report Development Process
 
 ## Introduction
 
@@ -75,7 +87,7 @@ set; in such case, the Editors may decide to group them.
 Produce a GitHub Pull Request to incorporate a formal text into a
 specification.
 
-##### Entry 
+##### Entry
 
 An issue can enter the drafting phase if either of the following is met:
 

--- a/test-suite-panel-charter.md
+++ b/test-suite-panel-charter.md
@@ -1,3 +1,15 @@
+<details open="">
+  <summary>Document Status</summary>
+  <dl>
+    <dt>Modified</dt>
+    <dd>2023-11-14</dd>
+    <dt>Reason</dt>
+    <dd>This document is no longer effective and is no longer being updated here. For the latest information on the <a href="https://www.w3.org/groups/cg/solid/">W3C Solid Community Group</a>, please refer to its <a href="https://github.com/w3c-cg/solid/">repository</a>, <a href="https://www.w3.org/community/solid/charter/">charter</a>, and <a href="https://github.com/w3c-cg/solid/blob/main/CONTRIBUTING.md">contributing guidelines</a>.</dd>
+  </dl>
+</details>
+
+---
+
 # Test Suite Panel Charter
 
 The mission of the Test Suite Panel as part of the W3C Solid Community Group (CG) is to give authors of technical reports and software implementers confidence that they can rely on the Solid ecosystem to deliver on the promise of interoperability based on open standards.


### PR DESCRIPTION
This PR adds document status (modified and reason) to documents pertaining to the Solid CG. It follows a [2023-10-10 Solid CG meeting](https://github.com/solid/specification/blob/main/meetings/2023-10-10.md#solid-process) actions with the goal to clean-up / update references to CG's work.