### PR TITLE
Add W3C Licenses as an alternative for deliverables

### DIFF
--- a/notifications-panel-charter.md
+++ b/notifications-panel-charter.md
@@ -136,7 +136,7 @@ This charter is written in accordance with Section 3.4, Votes of the W3C Process
 
 ## Licensing
 
-The panel will use the MIT license for all its deliverables.
+The panel will use the MIT license or a suitable W3C License for its deliverables.
 
 ## Patent Policy
 


### PR DESCRIPTION
This change will allow W3C licenses to be used for new deliverables created in the Solid project under the Solid-CG.

Request a vote on this at the next CG meeting!